### PR TITLE
Fix mp3 error

### DIFF
--- a/src/lib/MIDIPlayer.svelte
+++ b/src/lib/MIDIPlayer.svelte
@@ -167,7 +167,7 @@
         
         // get list of events (one track for each voice, plus one track with playback information (eventList[0]))
         let eventList = Player.getEvents();
-        console.log(Player.division);
+        // console.log(Player.division);
 
         // initialise object with chosen samples for each voice -- this needs to be updated manually to reflect the names of each voice and the chosen instrument from https://gleitz.github.io/midi-js-soundfonts/MusyngKite/names.json
         const instrumentsChosen = {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { view } from "../stores/viewChoice";
-
+  
   onMount(async () => {
     // Your selected Skeleton theme:
     await import("@skeletonlabs/skeleton/themes/theme-skeleton.css");

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   function handleClick() {
     invalidateAll();
   }
+
 </script>
 
 <h1>Bee-ing Human</h1>
@@ -50,6 +51,6 @@
 <InternalLink link="about">About</InternalLink>
 
 <ViewSelect on:click={handleClick} />
-<InternalLink link="content/{$view}/  " class="btn variant-filled"
+<InternalLink link="content/{$view}/" class="btn variant-filled"
   >Go</InternalLink
 >

--- a/src/routes/content/[view]/+page.server.js
+++ b/src/routes/content/[view]/+page.server.js
@@ -2,6 +2,7 @@ import { views } from "../data.js";
 import { error } from "@sveltejs/kit";
 import parseMD from "parse-md";
 import { loadMei } from "../../../utils/loadFunctions.js";
+import { base } from "$app/paths";
 
 
 export async function load({ fetch, params }) {
@@ -13,7 +14,6 @@ export async function load({ fetch, params }) {
   // get list of sections
   // import.meta.glob does not allow for dynamic variables in the search path, so it needs a switch statement to adjust based on the selected view
   // will need to be adapted if different/more views are necessary
-  console.log(view.slug);
   switch (view.slug) {
     case "literature":
       listSections = import.meta.glob("/static/content/literature/*.md", {
@@ -54,27 +54,12 @@ export async function load({ fetch, params }) {
   // add section metadata and data to export view
   view["sections"] = sections;
 
-  // TEST CETEICEAN
-  // This would be necessary for a more granular approach to implement CETEIcean, but is not needed for the simple approach;
-  // let tei = '';
-  // let teiString = '';
-  // if (view.slug === 'literature') {
-  //   // Get the content of the TEI file into a string
-  //   teiString = await fetch("literature/data/test2.xml")
-  //     .then(function(response) {
-  //       if (response.ok) {
-  //         return response.text();
-  //       }
-  //     });
-
-  //   tei = transformTEI(teiString);
-
-  // }
-
   // Load MEI if in the music view
   if (view.slug === 'music') {
     // fetch MEI file, convert to string;
-    let meiString = await fetch('music/data/CRIM_Model_0001.mei')
+    let url = `${base}/content/${view.slug}/data/CRIM_Model_0001.mei`;
+    console.log(url);
+    let meiString = await fetch(url)
     .then(function(response) {
         if (response.ok) {
         return response.text();

--- a/src/routes/content/[view]/+page.svelte
+++ b/src/routes/content/[view]/+page.svelte
@@ -6,6 +6,8 @@
   import AudioPlayer from "../../../lib/AudioPlayer.svelte";
   import MeiSimple from "../../../lib/MEISimple.svelte";
 
+  let audioPath = `${base}/content/music/media/virtualbarbershop.mp3`
+
 </script>
 
 <h1>View page</h1>
@@ -25,7 +27,7 @@
   <TEISimple path = "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/dev/1623_consolidated.xml"/>
 {:else if data.view.slug === 'music'}
   <h3>Binaural recording test</h3>
-  <AudioPlayer audioPath = "{base}/content/music/media/virtualbarbershop.mp3"/>
+  <AudioPlayer {audioPath}/>
   <h3>MEI engraving and playback test</h3>
   {#if 'mei' in data.view}
     <MeiSimple meiSvg = {data.view.mei.svg} meiMidi = {data.view.mei.midi} timeMap = {data.view.mei.timeMap}></MeiSimple>

--- a/src/routes/content/[view]/+page.svelte
+++ b/src/routes/content/[view]/+page.svelte
@@ -7,6 +7,7 @@
   import MeiSimple from "../../../lib/MEISimple.svelte";
 
   let audioPath = `${base}/content/music/media/virtualbarbershop.mp3`
+  console.log(audioPath)
 
 </script>
 
@@ -21,9 +22,6 @@
 
 {#if data.view.slug === "literature"}
   <h3>Test</h3>
-  <!-- <TeiDocument doc = {data.tei.content} elements = {data.tei.elements}></TeiDocument> -->
-  <!-- <TEISimple path = "{base}/content/literature/data/1623.xml"/> -->
-  <!-- Access TEI directly from github repo -->
   <TEISimple path = "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/dev/1623_consolidated.xml"/>
 {:else if data.view.slug === 'music'}
   <h3>Binaural recording test</h3>

--- a/src/routes/content/[view]/+page.svelte
+++ b/src/routes/content/[view]/+page.svelte
@@ -7,7 +7,6 @@
   import MeiSimple from "../../../lib/MEISimple.svelte";
 
   let audioPath = `${base}/content/music/media/virtualbarbershop.mp3`
-  console.log(audioPath)
 
 </script>
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,7 +6,7 @@ const config = {
   extensions: [".svelte"],
 
   paths: {
-    base: "/beeing-human-web",
+    base: process.env.NODE_ENV === 'production' ? "/beeing-human-web" : '',
   },
 
   kit: {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,10 +5,6 @@ import adapter from "@sveltejs/adapter-static";
 const config = {
   extensions: [".svelte"],
 
-  paths: {
-    base: process.env.NODE_ENV === 'production' ? "/beeing-human-web" : '',
-  },
-
   kit: {
     // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
     // If your environment is not supported or you settled on a specific environment, switch out the adapter.
@@ -16,7 +12,12 @@ const config = {
     adapter: adapter(),
     alias: {
       'utils': 'src/utils',
-    }
+    },
+    paths: {
+      base: process.argv.includes('dev') ? '' : process.env.BASE_PATH,
+      assets: '',
+      relative: true,
+    },
   },
 
   preprocess: [preprocess()],

--- a/tests/E2E/HomepageLoad.test.js
+++ b/tests/E2E/HomepageLoad.test.js
@@ -15,5 +15,5 @@ test('Page loads and has expected ViewSelector', async({page}) => {
 test('Page loads and has link to About page', async({page}) => {
   await page.goto("/");
   const aboutLink = await page.getByRole('link', { name: 'About' }).getAttribute('href');
-  expect(aboutLink).toBe('/about');
+  expect(aboutLink).toContain('about');
 })


### PR DESCRIPTION
## Description

Hard reload of pages resulted in 404 for static files. The problem was in the config of the paths in the adapter for static pages. It needed a 'relative: true' in `config.kit.paths`, otherwise it would try to look for the files in the base path, rather than the `beeing-human-web`. Path was corrected and the option means it is now able to find the correct files, and the hard reset still works.

Fixes #48 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Run automated checks to make sure everything else remains working, and multiple manual tests with deployments, as the problem only manifests itself in prod.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
