### PR TITLE
Tiagosousagarcia/issue104

### DIFF
--- a/src/lib/IIIFViewer.svelte
+++ b/src/lib/IIIFViewer.svelte
@@ -118,7 +118,6 @@
         }
         loaded = true;
 
-        // Listen to event 'nextPage'
         window.addEventListener("sigInView", (evt) => {
             if (evt.detail.sig != teiViewerState.currentSignature) {
                 // find the index of the signature in the array

--- a/src/lib/IIIFViewer.svelte
+++ b/src/lib/IIIFViewer.svelte
@@ -1,7 +1,9 @@
 <script>
     import { onDestroy, onMount } from "svelte";
     import { browser } from "$app/environment";
-    import {elementReady} from '../utils/generalHelpers'
+    import { elementReady } from "../utils/generalHelpers";
+
+    import { teiViewerState } from "../stores/teiViewer.svelte";
 
     // This needs to be imported only on the browser, otherwise it will generate an error
     // import "tify";
@@ -42,33 +44,44 @@
             await iiif.ready.then(() => {
                 // Add event listener to the next page button
                 elementReady(".tify-scan-page-button.-next").then(() => {
-                    const nextButton = document.querySelector(".tify-scan-page-button.-next");
-                    nextButton.addEventListener('click', () => {
-                        currentPage += 1;
-                    })
-                })
-
-                elementReady(".tify-header-button[title='Next page']").then(() => {
-                    const nextButton = document.querySelector(".tify-header-button[title='Next page'");
-                    nextButton.addEventListener('click', () => {
+                    const nextButton = document.querySelector(
+                        ".tify-scan-page-button.-next",
+                    );
+                    nextButton.addEventListener("click", () => {
                         currentPage += 1;
                     });
-                })
+                });
 
-                elementReady(".tify-scan-page-button.-previous").then(() =>{
-                    const prevButton = document.querySelector(".tify-scan-page-button.-previous");
-                    prevButton.addEventListener('click', () => {
-                        currentPage -= 1;
-                    })
-                })
+                elementReady(".tify-header-button[title='Next page']").then(
+                    () => {
+                        const nextButton = document.querySelector(
+                            ".tify-header-button[title='Next page'",
+                        );
+                        nextButton.addEventListener("click", () => {
+                            currentPage += 1;
+                        });
+                    },
+                );
 
-                elementReady(".tify-header-button[title='Previous page']").then(() => {
-                    const prevButton = document.querySelector(".tify-header-button[title='Previous page'");
-                    prevButton.addEventListener('click', () => {
+                elementReady(".tify-scan-page-button.-previous").then(() => {
+                    const prevButton = document.querySelector(
+                        ".tify-scan-page-button.-previous",
+                    );
+                    prevButton.addEventListener("click", () => {
                         currentPage -= 1;
                     });
-                })
+                });
 
+                elementReady(".tify-header-button[title='Previous page']").then(
+                    () => {
+                        const prevButton = document.querySelector(
+                            ".tify-header-button[title='Previous page'",
+                        );
+                        prevButton.addEventListener("click", () => {
+                            currentPage -= 1;
+                        });
+                    },
+                );
             });
         } catch (e) {
             console.warn("tify is not ready", e);
@@ -79,28 +92,7 @@
         try {
             await iiif.ready.then(() => {
                 iiif.setPage([parseInt(pageNumber)]);
-            });
-        } catch (e) {
-            console.warn("tify is not ready");
-        }
-    }
-
-    async function previousPage() {
-        try {
-            await iiif.ready.then(() => {
-                currentPage -= 1;
-                changePage(currentPage);
-            });
-        } catch (e) {
-            console.warn("tify is not ready", e);
-        }
-    }
-
-    async function nextPage() {
-        try {
-            await iiif.ready.then(() => {
-                currentPage += 1;
-                changePage(currentPage);
+                currentPage = pageNumber;
             });
         } catch (e) {
             console.warn("tify is not ready");
@@ -125,6 +117,39 @@
             }
         }
         loaded = true;
+
+        // Listen to event 'nextPage'
+        window.addEventListener("sigInView", (evt) => {
+            if (evt.detail.sig != teiViewerState.currentSignature) {
+                // find the index of the signature in the array
+                const index = teiViewerState.signatures.indexOf(evt.detail.sig);
+                // adjust the page based on the starting page of the iiif manifesto
+                changePage(index + parseInt(startPage));
+                // update the current signature in the store
+                teiViewerState.currentSignature = evt.detail.sig;
+            }
+        });
+    });
+
+    $effect(() => {
+        if (
+            currentPage !==
+            teiViewerState.signatures.indexOf(teiViewerState.currentSignature) +
+                parseInt(startPage)
+        ) {
+            // set currentSignature to the signature of the current page in the viewer
+            teiViewerState.currentSignature =
+                teiViewerState.signatures[currentPage - parseInt(startPage)];
+            // send iiiPageChange event
+            // sends the index of the signature it should scroll to -> because PBs appear at the top of the page, that should be the preceding signature rather than the current one
+            window.dispatchEvent(
+                new CustomEvent("iiifPageChange", {
+                    detail: {
+                        indexOfNewPb: currentPage - parseInt(startPage),
+                    },
+                }),
+            );
+        }
     });
 
     onDestroy(() => {
@@ -134,9 +159,6 @@
     });
 </script>
 
-{@debug currentPage}
+{@debug teiViewerState, currentPage}
 
-<button onclick={() => previousPage()}>-</button><button
-    onclick={() => changePage(2)}>Go to Page 2</button
-><button onclick={() => nextPage()}>+</button>
 <div id="facsimile-viewer" class="h-full"></div>

--- a/src/lib/IIIFViewer.svelte
+++ b/src/lib/IIIFViewer.svelte
@@ -1,7 +1,7 @@
 <script>
-
     import { onDestroy, onMount } from "svelte";
     import { browser } from "$app/environment";
+    import {elementReady} from '../utils/generalHelpers'
 
     // This needs to be imported only on the browser, otherwise it will generate an error
     // import "tify";
@@ -9,6 +9,7 @@
 
     let loaded = $state(false);
     let iiif = $state(undefined);
+    let currentPage = $state(undefined);
 
     let { manifest = undefined, startPage = undefined } = $props();
 
@@ -17,20 +18,60 @@
             container: "#facsimile-viewer",
             manifestUrl: manifest,
         });
-        removeHeader()
+        removeHeader();
+        addListenersToButtons();
     }
 
     async function removeHeader() {
         try {
             await iiif.ready.then(() => {
                 iiif.setPage([parseInt(startPage)]);
-                const iiifTitleHeader = document.getElementsByClassName('tify-header-title')[0];
+                const iiifTitleHeader =
+                    document.getElementsByClassName("tify-header-title")[0];
                 if (iiifTitleHeader) {
                     iiifTitleHeader.remove();
                 }
-            })
+            });
         } catch (e) {
-            console.warn('tify is not ready')
+            console.warn("tify is not ready");
+        }
+    }
+
+    async function addListenersToButtons() {
+        try {
+            await iiif.ready.then(() => {
+                // Add event listener to the next page button
+                elementReady(".tify-scan-page-button.-next").then(() => {
+                    const nextButton = document.querySelector(".tify-scan-page-button.-next");
+                    nextButton.addEventListener('click', () => {
+                        currentPage += 1;
+                    })
+                })
+
+                elementReady(".tify-header-button[title='Next page']").then(() => {
+                    const nextButton = document.querySelector(".tify-header-button[title='Next page'");
+                    nextButton.addEventListener('click', () => {
+                        currentPage += 1;
+                    });
+                })
+
+                elementReady(".tify-scan-page-button.-previous").then(() =>{
+                    const prevButton = document.querySelector(".tify-scan-page-button.-previous");
+                    prevButton.addEventListener('click', () => {
+                        currentPage -= 1;
+                    })
+                })
+
+                elementReady(".tify-header-button[title='Previous page']").then(() => {
+                    const prevButton = document.querySelector(".tify-header-button[title='Previous page'");
+                    prevButton.addEventListener('click', () => {
+                        currentPage -= 1;
+                    });
+                })
+
+            });
+        } catch (e) {
+            console.warn("tify is not ready", e);
         }
     }
 
@@ -40,27 +81,29 @@
                 iiif.setPage([parseInt(pageNumber)]);
             });
         } catch (e) {
-            console.warn('tify is not ready');
+            console.warn("tify is not ready");
         }
     }
 
     async function previousPage() {
         try {
             await iiif.ready.then(() => {
-                console.log(iiif.viewer)
+                currentPage -= 1;
+                changePage(currentPage);
             });
         } catch (e) {
-            console.warn('tify is not ready', e);
+            console.warn("tify is not ready", e);
         }
     }
 
     async function nextPage() {
         try {
             await iiif.ready.then(() => {
-                iiif.nextPage();
+                currentPage += 1;
+                changePage(currentPage);
             });
         } catch (e) {
-            console.warn('tify is not ready');
+            console.warn("tify is not ready");
         }
     }
 
@@ -70,10 +113,13 @@
                 // import tify and create a new instance
                 await import("tify").then(() => {
                     if (manifest && startPage) {
-                        buildIIIFY(manifest)
+                        buildIIIFY(manifest);
+                        if (currentPage === undefined) {
+                            currentPage = parseInt(startPage);
+                        }
                     }
                 });
-                loaded = true
+                loaded = true;
             } catch (e) {
                 console.error(e);
             }
@@ -86,11 +132,11 @@
             iiif.destroy();
         }
     });
-
 </script>
 
+{@debug currentPage}
 
-<button onclick={() => previousPage()}>-</button><button onclick={() => changePage(2)}>Go to Page 2</button><button onclick={() => nextPage()}>+</button>
-<div id="facsimile-viewer" class="h-full">
-</div>
-
+<button onclick={() => previousPage()}>-</button><button
+    onclick={() => changePage(2)}>Go to Page 2</button
+><button onclick={() => nextPage()}>+</button>
+<div id="facsimile-viewer" class="h-full"></div>

--- a/src/lib/IIIFViewer.svelte
+++ b/src/lib/IIIFViewer.svelte
@@ -34,6 +34,36 @@
         }
     }
 
+    async function changePage(pageNumber) {
+        try {
+            await iiif.ready.then(() => {
+                iiif.setPage([parseInt(pageNumber)]);
+            });
+        } catch (e) {
+            console.warn('tify is not ready');
+        }
+    }
+
+    async function previousPage() {
+        try {
+            await iiif.ready.then(() => {
+                console.log(iiif.viewer)
+            });
+        } catch (e) {
+            console.warn('tify is not ready', e);
+        }
+    }
+
+    async function nextPage() {
+        try {
+            await iiif.ready.then(() => {
+                iiif.nextPage();
+            });
+        } catch (e) {
+            console.warn('tify is not ready');
+        }
+    }
+
     onMount(async () => {
         if (browser) {
             try {
@@ -59,6 +89,8 @@
 
 </script>
 
+
+<button onclick={() => previousPage()}>-</button><button onclick={() => changePage(2)}>Go to Page 2</button><button onclick={() => nextPage()}>+</button>
 <div id="facsimile-viewer" class="h-full">
 </div>
 

--- a/src/lib/TEISimple.svelte
+++ b/src/lib/TEISimple.svelte
@@ -15,6 +15,8 @@
     import { onMount } from 'svelte';
     import CETEI from 'CETEIcean';
     import {teiBehaviours} from '../utils/teiBehaviours';
+
+    import {teiViewerState} from '../stores/teiViewer.svelte';
     
 
 
@@ -53,7 +55,26 @@
             if (path === '') {
                 throw 'No path specified';
             }
-            loadTei(path)
+            await loadTei(path).then(() => {
+                // get an array of all pbs
+                const pbElm = document.querySelectorAll('tei-pb');
+                // put the n attribute of each pb in the teiVierState store
+                pbElm.forEach(pb => {
+                    teiViewerState.signatures.push(pb.getAttribute('n'))
+                })
+                teiViewerState.currentSignature = teiViewerState.signatures[0];
+                // add event listener for iiifPageChange
+                window.addEventListener('iiifPageChange', (e) => {
+                    // scroll into view the element with the same n attribute as the currentSignature
+                    const pb = document.querySelector(`tei-pb[n="${teiViewerState.currentSignature}"]`);
+                    // only do this if the pb exists and is not already in view
+                    if (pb && !pb.getBoundingClientRect().top >= 0) {
+                        pb.scrollIntoView({behavior: 'smooth', block: 'start'});
+                        console.log('scrolling to', teiViewerState.currentSignature, pb)
+                    }
+                })
+                loaded = true;
+            });
         } catch (err) {
             error = err.toString();
             loaded = false;
@@ -63,6 +84,7 @@
 
 </script>
 
+{@debug teiViewerState}
 
 <div id='TEI-container' data-testid="TEI-container">
     {#if !loaded}

--- a/src/lib/TEISimple.svelte
+++ b/src/lib/TEISimple.svelte
@@ -12,26 +12,22 @@
 -->
 
 <script>
-    import { onMount } from 'svelte';
-    import CETEI from 'CETEIcean';
-    import {teiBehaviours} from '../utils/teiBehaviours';
+    import { onMount } from "svelte";
+    import CETEI from "CETEIcean";
+    import { teiBehaviours } from "../utils/teiBehaviours";
 
-    import {teiViewerState} from '../stores/teiViewer.svelte';
-    
+    import { teiViewerState } from "../stores/teiViewer.svelte";
 
-
-    let { path = '', statusCheck} = $props();
+    let { path = "", statusCheck } = $props();
 
     let loaded = $state(false);
     let error = $state(undefined);
 
-
     async function loadTei(path) {
-        
-        console.log('adding tei')
-        loaded = false
-        const parent = document.getElementById('TEI-container');
-        
+        console.log("adding tei");
+        loaded = false;
+        const parent = document.getElementById("TEI-container");
+
         // cleans the parent container, in case it has any previous content
         while (parent.firstChild) {
             parent.removeChild(parent.lastChild);
@@ -40,55 +36,72 @@
         // inserts TEI content
         var cetei = new CETEI();
         cetei.addBehaviors(teiBehaviours);
-        await cetei.getHTML5(path, function(data) {
+        await cetei
+            .getHTML5(path, function (data) {
                 parent.appendChild(data);
-        }).then(() => {
-            console.log('finished')
-            loaded = true;
-            statusCheck({loaded: 'loaded'})
-            return path;
-        });
+            })
+            .then(() => {
+                console.log("finished");
+                loaded = true;
+                statusCheck({ loaded: "loaded" });
+                return path;
+            });
     }
 
     onMount(async () => {
         try {
-            if (path === '') {
-                throw 'No path specified';
+            if (path === "") {
+                throw "No path specified";
             }
             await loadTei(path).then(() => {
                 // get an array of all pbs
-                const pbElm = document.querySelectorAll('tei-pb');
+                const pbElm = document.querySelectorAll("tei-pb");
                 // put the n attribute of each pb in the teiVierState store
-                pbElm.forEach(pb => {
-                    teiViewerState.signatures.push(pb.getAttribute('n'))
-                })
+                pbElm.forEach((pb) => {
+                    teiViewerState.signatures.push(pb.getAttribute("n"));
+                });
                 teiViewerState.currentSignature = teiViewerState.signatures[0];
                 // add event listener for iiifPageChange
-                window.addEventListener('iiifPageChange', (e) => {
+                window.addEventListener("iiifPageChange", (e) => {
                     // scroll into view the element with the same n attribute as the currentSignature
-                    const pb = document.querySelector(`tei-pb[n="${teiViewerState.currentSignature}"]`);
+                    let pb = document.querySelector(
+                        `tei-pb[n="${teiViewerState.currentSignature}"]`,
+                    );
+
+                    // if pb is hidden, find the closest visible element and scroll to that
+                    if (pb && pb.classList.contains("hidden")) {
+                        // find closest element that is not hidden
+                        let closestVisible = pb.previousElementSibling;
+                        while (closestVisible.classList.contains("hidden")) {
+                            closestVisible =
+                                closestVisible.previousElementSibling;
+                        }
+                        pb = closestVisible;
+                    }
+
                     // only do this if the pb exists and is not already in view
                     if (pb && !pb.getBoundingClientRect().top >= 0) {
-                        pb.scrollIntoView({behavior: 'smooth', block: 'start'});
-                        console.log('scrolling to', teiViewerState.currentSignature, pb)
+                        pb.scrollIntoView({
+                            behavior: "smooth",
+                            block: "start",
+                        });
                     }
-                })
+                });
                 loaded = true;
             });
         } catch (err) {
             error = err.toString();
             loaded = false;
-            return
+            return;
         }
-    })
-
+    });
 </script>
 
 {@debug teiViewerState}
 
-<div id='TEI-container' data-testid="TEI-container">
+<div id="TEI-container" data-testid="TEI-container">
     {#if !loaded}
-        <p id='loading-message'>Loading...</p>
+        <p id="loading-message">Loading...</p>
     {/if}
     {#if error}
         <p data-testid="error-message">{error}</p>

--- a/src/stores/teiViewer.svelte.js
+++ b/src/stores/teiViewer.svelte.js
@@ -1,0 +1,4 @@
+export const teiViewerState = $state({
+    signatures: [],
+    currentSignature: undefined,
+})

--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -200,6 +200,21 @@ export let teiBehaviours = {
                 }
             } else {
                 addTailwindClasslist(elt, 'hidden')
+                // find closest element that is not hidden
+                let closestVisible = elt.previousElementSibling;
+                while (closestVisible.classList.contains('hidden')) {
+                    closestVisible = closestVisible.previousElementSibling;
+                }
+                // dispatches an event from the closest visible element every time it scrolls into view
+                let text = document.getElementById('TEI-container').parentElement;
+                text.addEventListener('scroll', function () {
+                    let rect = closestVisible.getBoundingClientRect();
+                    if(rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
+                        let event = new CustomEvent('sigInView', { detail: {sig: elt.getAttribute('n')} });
+                        window.dispatchEvent(event);
+                    }
+                })
+
             }
 
         },

--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -180,22 +180,22 @@ export let teiBehaviours = {
             let emptySigs = ['¶3r', 'A3r', 'B1r']
             if (!findIfAncestor(elt, 'tei-list')) {
                 // if pb is in the contents page ignore it, causing too many issues
+                // check if the element is in view anytime the tei-text is scrolled
+                // find tei-text
+                let text = document.getElementById('TEI-container').parentElement;
+                text.addEventListener('scroll', function () {
+                    let rect = elt.getBoundingClientRect();
+                    if (rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
+                        // if the element is in view, send a custom element with the signature
+                        let event = new CustomEvent('sigInView', { detail: { sig: elt.getAttribute('n') } });
+                        window.dispatchEvent(event);
+                    }
+                });
                 if (this.sigsDict[elt.getAttribute('n')] && !emptySigs.includes(elt.getAttribute('n'))) {
                     var sig = document.createElement('p');
                     sig.innerHTML = this.sigsDict[elt.getAttribute('n')];
                     sig.classList.add('signature')
-                    
-                    // check if the element is in view anytime the tei-text is scrolled
-                    // find tei-text
-                    let text = document.getElementById('TEI-container').parentElement;
-                    text.addEventListener('scroll', function () {
-                        let rect = elt.getBoundingClientRect();
-                        if (rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
-                            // if the element is in view, send a custom element with the signature
-                            let event = new CustomEvent('sigInView', { detail: {sig: elt.getAttribute('n')} });
-                            window.dispatchEvent(event);
-                        }
-                    });
+
                     return sig
                 }
             } else {
@@ -209,8 +209,8 @@ export let teiBehaviours = {
                 let text = document.getElementById('TEI-container').parentElement;
                 text.addEventListener('scroll', function () {
                     let rect = closestVisible.getBoundingClientRect();
-                    if(rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
-                        let event = new CustomEvent('sigInView', { detail: {sig: elt.getAttribute('n')} });
+                    if (rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
+                        let event = new CustomEvent('sigInView', { detail: { sig: elt.getAttribute('n') } });
                         window.dispatchEvent(event);
                     }
                 })

--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -48,7 +48,7 @@ export let teiBehaviours = {
                     addTailwindClasslist(elt, 'text-sm')
                 }
             ],
-            ["[type='editorial']", function(elt) {
+            ["[type='editorial']", function (elt) {
                 let event = new CustomEvent('editorialNoteClicked', { detail: elt });
 
                 elt.onclick = function () {
@@ -184,11 +184,24 @@ export let teiBehaviours = {
                     var sig = document.createElement('p');
                     sig.innerHTML = this.sigsDict[elt.getAttribute('n')];
                     sig.classList.add('signature')
+                    
+                    // check if the element is in view anytime the tei-text is scrolled
+                    // find tei-text
+                    let text = document.getElementById('TEI-container').parentElement;
+                    text.addEventListener('scroll', function () {
+                        let rect = elt.getBoundingClientRect();
+                        if (rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
+                            // if the element is in view, send a custom element with the signature
+                            let event = new CustomEvent('sigInView', { detail: {sig: elt.getAttribute('n')} });
+                            window.dispatchEvent(event);
+                        }
+                    });
                     return sig
                 }
             } else {
                 addTailwindClasslist(elt, 'hidden')
             }
+
         },
         "cb": function (elt) {
             // hides the cb, causing too many issues

--- a/tests/E2E/ViewLit.test.js
+++ b/tests/E2E/ViewLit.test.js
@@ -36,7 +36,7 @@ test.describe('Page content containers exist tests', () => {
         await expect(page).toHaveURL('/literature');
         const articles = await page.getByRole('article').all();
         expect(articles.length).toBeGreaterThan(0);
-    });    
+    });
 })
 
 test.describe('Transcription page has TEI content', () => {
@@ -108,11 +108,60 @@ test.describe('Page has IIIF viewer content', () => {
         console.log(`Running ${testInfo.title}`);
         await page.goto('/literature/transcription');
     });
-    
-    test('Expect that page contains the IIIF viewer', async ({page}) => {
+
+    test('Expect that page contains the IIIF viewer', async ({ page }) => {
         await expect(page).toHaveURL('/literature/transcription');
         const iiifViewer = page.getByTestId('iiif-viewer');
         await expect(iiifViewer).toBeVisible();
     })
 })
 
+
+
+// // Synchronicity between iiifviewer and transcription
+// test.describe('Synchronicity between IIIF viewer and transcription', () => {
+//     test.beforeEach('Open start URL', async ({ page }, testInfo) => {
+//         console.log(`Running ${testInfo.title}`);
+//         await page.goto('/literature/transcription');
+//     });
+
+//     test('Expect that when the user clicks on the next page button in the IIIF viewer, the transcription is updated', async ({ page }) => {
+//         await expect(page).toHaveURL('/literature/transcription');
+//         const iiifViewer = page.getByTestId('iiif-viewer');
+//         await expect(iiifViewer).toBeVisible();
+//         // await until the IIIF viewer is loaded
+//         await page.waitForSelector('pb');
+//         const nextPageButtons = page.getByTitle('Next page').all();
+//         const nextPageButton = await nextPageButtons[0];
+//         await expect(nextPageButton).toBeVisible();
+//         // get the first visible pb element in the viewport
+//         pbs = await page.locator('pb').all();
+//         const firstVisiblePb = await findFirstVisiblePb(pbs);
+
+//         // click the next page four times
+//         await nextPageButton.click();
+//         await nextPageButton.click();
+//         await nextPageButton.click();
+//         await nextPageButton.click();
+
+//         // get the first visible pb element in the viewport
+//         const firstVisiblePbAfter = await findFirstVisiblePb(pbs);
+
+//         // check that the first visible pb element has changed
+//         expect(firstVisiblePb).not.toEqual(firstVisiblePbAfter);
+//     })
+// })
+
+// async function findFirstVisiblePb(pbs) {
+//     let firstVisiblePb = undefined;
+//     while (firstVisiblePb === undefined) {
+//         for (pb of pbs) {
+//             const boundingBox = await pb.boundingBox();
+//             if (boundingBox !== null && boundingBox.y > 0) {
+//                 firstVisiblePb = pb;
+//                 break;
+//             }
+//         }
+//     }
+//     return firstVisiblePb
+// }


### PR DESCRIPTION
## Description

Introduces synchronicity between the transcription and the facsimile viewer when looking at them in 'both' mode. There are a few known bugs that will be sorted later on, namely:

- [ ] if the facsimile viewer is in double page mode, it will prevent you from scrolling to the second page #bug #todo #transcription-viewer
- [ ] Changing the pages directly in the facsimile viewer (i.e., by writing a new number), does not scroll the transcription #bug #todo #transcription-viewer 
- [ ] using the 'last page' or the 'first page' option in the facsimile viewer does not scroll the transcription #bug #todo #transcription-viewer 
- [ ] Going directly to a link in the transcription, or clicking through one, does not change the page on the facsimile #todo #bug #transcription-viewer 

Fixes #104 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual testing. Automated tests will be added later on;

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

