### PR TITLE
Tiagosousagarcia/issue129

### DIFF
--- a/src/lib/ImgModal.svelte
+++ b/src/lib/ImgModal.svelte
@@ -56,21 +56,21 @@
 
         <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
             <div
-                class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0"
+                class="flex min-h-full items-center justify-center md:p-4 text-center"
             >
                 <div
-                    class="rounded-lg text-left shadow-xl transition-all my-8 w-full max-w-lg md:w-fit md:max-w-none md:max-w-dvw px-12 pb-6 pt-4 bg-surface-50"
+                    class="md:rounded-lg text-left shadow-xl transition-all md:my-8 w-full max-w-lg md:w-fit md:max-w-none md:max-w-dvw md:px-12 md:pb-6 md:pt-4 py-1 bg-surface-50"
                     transition:fly={{ y: 20, duration: 300 }}
                     id="modal-screen"
                 >
-                    <div class="flex justify-end">
+                    <div class="flex justify-end p-2">
                         <button
                             type="button"
                             class="text-xl hover:font-bold"
                             onclick={buttonClickedHandler}>&#x2715;</button
                         >
                     </div>
-                    <div class="flex flex-col items-center gap-8">
+                    <div class="flex flex-col items-center gap-2 md:gap-8">
                             <img src={base + imgDetails.url} alt={imgDetails.alt} />
                             {#if imgDetails.caption}
                                 <p class="w-fit">{imgDetails.caption}</p>

--- a/src/lib/ImgModal.svelte
+++ b/src/lib/ImgModal.svelte
@@ -40,7 +40,7 @@
     });
 </script>
 
-{#if show}
+`{#if show}
     <div
         class="relative z-10"
         aria-labelledby="modal-title"
@@ -59,25 +59,26 @@
                 class="flex min-h-full items-center justify-center md:p-4 text-center"
             >
                 <div
-                    class="md:rounded-lg text-left shadow-xl transition-all md:my-8 w-full max-w-lg md:w-fit md:max-w-none md:max-w-dvw md:px-12 md:pb-6 md:pt-4 py-1 bg-surface-50"
+                    class="md:rounded-lg text-left shadow-xl transition-all md:my-8 w-full max-w-lg md:w-fit md:max-w-none md:max-w-dvw md:px-12 md:pb-6 md:pt-4 py-1 bg-surface-50 md:max-h-fit flex flex-col items-center gap-4"
                     transition:fly={{ y: 20, duration: 300 }}
                     id="modal-screen"
                 >
-                    <div class="flex justify-end p-2">
                         <button
                             type="button"
-                            class="text-xl hover:font-bold"
+                            class="text-xl hover:font-bold self-end p-2"
                             onclick={buttonClickedHandler}>&#x2715;</button
                         >
-                    </div>
-                    <div class="flex flex-col items-center gap-2 md:gap-8">
-                            <img src={base + imgDetails.url} alt={imgDetails.alt} />
-                            {#if imgDetails.caption}
-                                <p class="w-fit">{imgDetails.caption}</p>
-                            {/if}
-                    </div>
+                    <img
+                        src={base + imgDetails.url}
+                        alt={imgDetails.alt}
+                        class="object-contain max-h-[75vh]"
+                    />
+                    {#if imgDetails.caption}
+                        <p class="w-fit">{imgDetails.caption}</p>
+                    {/if}
                 </div>
             </div>
         </div>
     </div>
 {/if}
+`


### PR DESCRIPTION
## Description

Readjusts the modal image viewer in mobile

Makes changes to the behaviour of very large images in desktop view: instead of full size, they occupy a maximum percentage of the viewport -- i.e., no scrolling.

Fixes #129 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.

<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
