### PR TITLE
corrects problem with facsimile being stuck if there was a pb between…

### DIFF
--- a/src/lib/IIIFViewer.svelte
+++ b/src/lib/IIIFViewer.svelte
@@ -11,7 +11,6 @@
     // import "tify";
     import "tify/dist/tify.css";
 
-    let loaded = $state(false);
     let iiif = $state(undefined);
     let currentPage = $state(undefined);
 
@@ -139,12 +138,10 @@
                         buildIIIFY(manifest);
                     }
                 });
-                loaded = true;
             } catch (e) {
                 console.error(e);
             }
         }
-        loaded = true;
 
         window.addEventListener("sigInView", (evt) => {
             if (evt.detail.sig != teiViewerState.currentSignature) {

--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -1,5 +1,5 @@
 import { addTailwindClasslist, findIfAncestor, findInDescendant, findPreviousElement, removeTailwindClasslist, wrapChildren, wrapElement } from "./generalHelpers";
-import { teiSetBodyLayout } from "./teiBehavioursHelper";
+import { getElementRect, teiSetBodyLayout } from "./teiBehavioursHelper";
 import ornament from '../assets/text_divider.svg'
 
 import transcriptionData from './../routes/(sections)/literature/transcription/transcriptionData.json'
@@ -240,8 +240,9 @@ export let teiBehaviours = {
                 // find tei-text
                 let text = document.getElementById('TEI-container').parentElement;
                 text.addEventListener('scroll', function () {
-                    let rect = elt.getBoundingClientRect();
-                    if (rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
+                    let rect = getElementRect(elt);
+
+                    if (rect && (rect.top >= 0 && rect.bottom <= window.innerHeight / 3)) {
                         // if the element is in view, send a custom element with the signature
                         let event = new CustomEvent('sigInView', { detail: { sig: elt.getAttribute('n') } });
                         window.dispatchEvent(event);
@@ -264,8 +265,9 @@ export let teiBehaviours = {
                 // dispatches an event from the closest visible element every time it scrolls into view
                 let text = document.getElementById('TEI-container').parentElement;
                 text.addEventListener('scroll', function () {
-                    let rect = closestVisible.getBoundingClientRect();
-                    if (rect.top >= 0 && rect.bottom <= window.innerHeight / 3) {
+                    let rect = getElementRect(elt);
+
+                    if (rect && (rect.top >= 0 && rect.bottom <= window.innerHeight / 3)) {
                         let event = new CustomEvent('sigInView', { detail: { sig: elt.getAttribute('n') } });
                         window.dispatchEvent(event);
                     }

--- a/src/utils/teiBehavioursHelper.js
+++ b/src/utils/teiBehavioursHelper.js
@@ -30,3 +30,14 @@ export function teiSetBodyLayout(elt) {
     
     }
 }
+
+export function getElementRect(elt) {
+    // with fragmented notes elements, getBoundingClientRect() was returning all 0s, so this function is a workaround to make sure the element is in the DOM and visible before checking if the element is in view and dispatching an event
+    
+    if (elt && elt.offsetParent !== null) {
+        return elt.getBoundingClientRect();
+    } else {
+        // console.warn('Element is not in the DOM or is hidden');
+        return null;
+    }
+}


### PR DESCRIPTION
… fragmented editorial notes

## Description

If fragmented editorial notes had a <pb/> between the <anchors>, the resulting consolidated file would, for some reason, not attach the <pb> to the DOM at the time it registers the behaviours and dispatches the sigInView event. Because the result of getBoundingClientRect() for an element that is not attached to the DOM is all zeros, it would qualify as being in View, and basically dispatch the event at every scroll / change action. 

Fixes #157 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated tests

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes