### PR TITLE
fixes the erasure of editorial notes

### DIFF
--- a/src/lib/NoteModal.svelte
+++ b/src/lib/NoteModal.svelte
@@ -138,7 +138,7 @@
             } else if (parentElement.tagName === 'TEI-NOTE') {
                 // add all the children to the altReadings array
                 parentElement.childNodes.forEach((child) => {
-                    altReadings.push(child);
+                    altReadings.push(child.cloneNode(true));
                 });
             }
             // for each altReading check if they are a textual node
@@ -156,8 +156,6 @@
         }
     });
 </script>
-
-{@debug message}
 
 {#if show}
     <div

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -377,7 +377,6 @@
 
         window.addEventListener("editorialNoteClicked", (e) => {
             // if the element contains the class 'isMarked', show the modal
-            console.log(e.detail);
             if (e.detail.classList.contains("isMarked")) {
                 showModal = true;
                 modalElement = e.detail;


### PR DESCRIPTION
## Description

Fixes the bug that was deleting editorial notes after they were first opened.

Process was moving the content of the note from its element to the modal; now a deep copy is performed instead. For some reason, a similar process for variation does not delete the note :man_shrugging: 

Fixes #158 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes