### PR TITLE
changed the rules of opposite to account for any ancestor of the curr…

### DIFF
--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -1,5 +1,5 @@
 import { addTailwindClasslist, findAncestor, findIfAncestor, findInDescendant, findPreviousElement, wrapChildren, wrapElement } from "./generalHelpers";
-import { checkForParentNotes, getElementRect, teiSetBodyLayout } from "./teiBehavioursHelper";
+import { checkAncestorForClass, checkForParentNotes, getElementRect, teiSetBodyLayout } from "./teiBehavioursHelper";
 import ornament from '../assets/text_divider.svg'
 
 import transcriptionData from './../routes/(sections)/literature/transcription/transcriptionData.json'
@@ -383,8 +383,8 @@ export let teiBehaviours = {
                 addTailwindClasslist(elt, 'italic')
             }],
             ["[rend=opposite]", function (elt) {
-                // if parent is italic, this should not be italic
-                if (elt.parentNode.classList.contains('italic')) {
+                // if any of its ancestors are in italics, remove the italic class
+                if (checkAncestorForClass(elt, 'italic')) {
                     elt.classList.remove('italic');
                     elt.classList.add('not-italic');
                 } else {

--- a/src/utils/teiBehavioursHelper.js
+++ b/src/utils/teiBehavioursHelper.js
@@ -80,3 +80,15 @@ export function checkForParentNotes(elt) {
     return parentRef;
 
 }
+
+export function checkAncestorForClass(elt, className) {
+    // checks to see if the element is contained by or a descendent of an element with a specific className
+    let parent = elt.parentNode;
+    while (parent.tagName != 'TEI-TEI') {
+        if (parent.classList.contains(className)) {
+            return true;
+        }
+        parent = parent.parentNode;
+    }
+    return false;
+}


### PR DESCRIPTION
…ent node having the italic class

## Description

Changes the rules for elements with `rend` `opposite` to take into account any ancestor, not just their immediate parent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

