### PR TITLE
Roman semicolons

### DIFF
--- a/src/routes/(sections)/literature/transcription/transcriptionData.json
+++ b/src/routes/(sections)/literature/transcription/transcriptionData.json
@@ -8,7 +8,7 @@
         "title": "1609 facsimile"
     },
     "1623": {
-        "teiURL": "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/refs/heads/dev/1623_consolidated.xml",
+        "teiURL": "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/refs/heads/roman-semicolons/1623_consolidated.xml",
         "teiMediaRoot": "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/refs/heads/dev/",
         "iiifManifest": "https://iiif.archive.org/iiif/RAM2023-1081/manifest.json",
         "manifestStartPage": "5",

--- a/src/routes/(sections)/literature/transcription/transcriptionData.json
+++ b/src/routes/(sections)/literature/transcription/transcriptionData.json
@@ -8,7 +8,7 @@
         "title": "1609 facsimile"
     },
     "1623": {
-        "teiURL": "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/refs/heads/roman-semicolons/1623_consolidated.xml",
+        "teiURL": "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/refs/heads/dev/1623_consolidated.xml",
         "teiMediaRoot": "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/refs/heads/dev/",
         "iiifManifest": "https://iiif.archive.org/iiif/RAM2023-1081/manifest.json",
         "manifestStartPage": "5",

--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -443,6 +443,9 @@ export let teiBehaviours = {
             ["[rend='italic']", function (elt) {
                 addTailwindClasslist(elt, "italic");
             }],
+            ["[rend='roman']", function (elt) {
+                addTailwindClasslist(elt, "not-italic");
+            }],
             ["[type='fragmentedNoteAttachement']", function (elt) {
                 // This is a fragment point of attachment for an editorial note, so any processing and styling is left to the TEI viwer component
 


### PR DESCRIPTION
## Description

Adds styling rule for `<seg rend='roman'>` for semi-colons to be rendered as non-italic

Fixes [issue in another repo](https://github.com/NewcastleRSE/beeing-human-tei-data/issues/123)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes