### PR TITLE
added minimal styling for reported quotes

### DIFF
--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -432,6 +432,14 @@ export let teiBehaviours = {
             }],
         ],
         "q": [
+            ["[type='reported']", function(elt) {
+                // insert text node at the start of the element
+                let text = document.createTextNode('"');
+                elt.insertBefore(text, elt.firstChild);
+                // insert text node at the end of the element
+                text = document.createTextNode('"');
+                elt.appendChild(text);
+            }],
             ["_", function (elt) {
                 addTailwindClasslist(elt, 'italic');
             }]


### PR DESCRIPTION
## Description

Adds quotation marks to the start and the end of text marked with `<q type='reported'>`. Looked into replicating the facsimile look of quotation marks at end of line but adds too much complexity.

Fixes [this issue](https://github.com/NewcastleRSE/beeing-human-tei-data/issues/124)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
