### PR TITLE
corrects config to identify the correct version on build for sentry

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,8 +10,10 @@ export default defineConfig({
       sourceMapsUploadOptions: {
         org: "ncl-rse",
         project: "beeing-human-web",
-        release: "beeing-human-web@" + process.env.npm_package_version,
-        environment: process.argv.includes('dev') ? 'development' : 'production',
+        release: {
+          name: "being-human-web@" + process.env.npm_package_version,
+        }
+
       },
     }),
     sveltekit(),


### PR DESCRIPTION
## Description

at build sentry was not collecting the correct release; corrected the sentySvelteKit options object in vite.config.js