### PR TITLE
adds ability to display two authors for editorial notes

### DIFF
--- a/src/lib/NoteModal.svelte
+++ b/src/lib/NoteModal.svelte
@@ -3,6 +3,7 @@
     import { fade, fly } from "svelte/transition";
     import TextDivider from "./TextDivider.svelte";
     import { base } from "$app/paths";
+    import { replaceState } from "$app/navigation";
 
     let { message, show = $bindable(false) } = $props();
     let buttonClicked = $state(false);
@@ -187,11 +188,14 @@
                     // Finds the author of the note
                     if (note.getAttribute("resp")) {
                         try {
-                            const person = document.querySelector(
-                                note.getAttribute("resp"),
-                            );
-                            let persName = person.querySelector("tei-persName");
-                            altReading.push(persName.cloneNode(true));
+                            
+                            let peopleCodes = note.getAttribute("resp").split(" ");
+                            // if there is more than one author, it finds all
+                            for (const persCode of peopleCodes) {
+                                const person = document.querySelector(persCode);
+                                let persName = person.querySelector("tei-persName");
+                                altReading.push(persName.cloneNode(true));
+                            }
                         } catch (e) {
                             console.warn(
                                 "Could not find the person element with the id: " +


### PR DESCRIPTION
## Description

Adds the ability to display multiple authors for editorial notes if they are encoded as `resp="#A1 #A2"`.

Fixes #190 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.

<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
