### PR TITLE
Tiagosousagarcia/issue191

### DIFF
--- a/src/lib/NoteModal.svelte
+++ b/src/lib/NoteModal.svelte
@@ -24,10 +24,9 @@
                     let singNoteDiv = document.createElement("div");
                     singNoteDiv.classList.add("mb-4");
                     for (const elRead of reading) {
-                        console.log(elRead)
                         if (elRead.tagName != "TEI-PERSNAME") {
-                            // check to see if it is hidden:
-                            if (elRead.classList.contains("hidden")) {
+                            // check to see if it is not a text node and not hidden:
+                            if (elRead.nodeType != 3 && elRead.classList.contains("hidden")) {
                                 elRead.classList.remove("hidden");
                             }
                             singNoteDiv.appendChild(elRead);
@@ -243,7 +242,7 @@
                 // create a list of all tei-rdg siblings of the message element
                 let siblings = parentElement[0].querySelectorAll("tei-rdg");
                 siblings.forEach((sibling) => {
-                    altReading.push(sibling);
+                    altReading.push(sibling.cloneNode(true));
                 });
                 altReadings.push(altReading);
             } else if (parentElement[0].tagName === "TEI-NOTE") {
@@ -295,8 +294,6 @@
         }
     });
 </script>
-
-{@debug altReadings}
 
 {#if show}
     <div

--- a/src/lib/NoteModal.svelte
+++ b/src/lib/NoteModal.svelte
@@ -3,7 +3,6 @@
     import { fade, fly } from "svelte/transition";
     import TextDivider from "./TextDivider.svelte";
     import { base } from "$app/paths";
-    import { replaceState } from "$app/navigation";
 
     let { message, show = $bindable(false) } = $props();
     let buttonClicked = $state(false);
@@ -16,6 +15,75 @@
     function close() {
         show = !show;
     }
+
+    function appendNotes() {
+        // attach readings to correct div
+        if (altReadings) {
+                const notesDiv = document.getElementById("note-content");
+                for (const [i, reading] of altReadings.entries()) {
+                    let singNoteDiv = document.createElement("div");
+                    singNoteDiv.classList.add("mb-4");
+                    for (const elRead of reading) {
+                        console.log(elRead)
+                        if (elRead.tagName != "TEI-PERSNAME") {
+                            // check to see if it is hidden:
+                            if (elRead.classList.contains("hidden")) {
+                                elRead.classList.remove("hidden");
+                            }
+                            singNoteDiv.appendChild(elRead);
+                        } else {
+                            let authorName = document.createElement("div");
+                            authorName.innerHTML = "— ";
+                            authorName.classList.add(
+                                "text-sm",
+                                "text-secondary-600",
+                                "italic",
+                                "mt-4",
+                                "pr-4",
+                                "text-right",
+                                "w-full"
+                            );
+                            let authorLink = document.createElement("a");
+                            authorLink.setAttribute(
+                                "href",
+                                `${base}/people/${elRead.getAttribute("corresp")}`,
+                            );
+                            authorLink.setAttribute("target", "_blank");
+                            authorLink.classList.add("hover:anchor");
+                            authorLink.innerHTML = elRead.innerHTML;
+                            authorName.appendChild(authorLink);
+                            singNoteDiv.appendChild(authorName);
+                        }
+                    }
+                    notesDiv.appendChild(singNoteDiv);
+                    if (altReadings.length > 1) {
+                        if (i < altReadings.length - 1) {
+                            // find the hidden text divider
+                            let textDivider = document.querySelector(
+                                ".text-divider.hidden",
+                            );
+                            if (textDivider) {
+                                textDivider.classList.remove("hidden");
+                                textDivider.classList.add("block");
+                                notesDiv.appendChild(textDivider);
+                            }
+                        }
+                    }
+                }
+            }
+    }
+
+    $effect(() => {
+        if (show) {
+            appendNotes();
+        } else {
+            // remove the notes
+            let noteContent = document.getElementById("note-content");
+            if (noteContent) {
+                noteContent.innerHTML = "";
+            }
+        }
+    })
 
     onMount(() => {
         // prevents window is not defined errors
@@ -38,6 +106,7 @@
                     buttonClicked = false;
                 }
             });
+            
         }
     });
 
@@ -188,12 +257,14 @@
                     // Finds the author of the note
                     if (note.getAttribute("resp")) {
                         try {
-                            
-                            let peopleCodes = note.getAttribute("resp").split(" ");
+                            let peopleCodes = note
+                                .getAttribute("resp")
+                                .split(" ");
                             // if there is more than one author, it finds all
                             for (const persCode of peopleCodes) {
                                 const person = document.querySelector(persCode);
-                                let persName = person.querySelector("tei-persName");
+                                let persName =
+                                    person.querySelector("tei-persName");
                                 altReading.push(persName.cloneNode(true));
                             }
                         } catch (e) {
@@ -224,6 +295,8 @@
         }
     });
 </script>
+
+{@debug altReadings}
 
 {#if show}
     <div
@@ -284,38 +357,8 @@
                                 <span class="h-1 w-full {accentColour} my-2"
                                 ></span>
                             </div>
-                            <div class="mt-2">
-                                {#each altReadings as reading, i}
-                                    <div class="mb-4">
-                                        {#each reading as el}
-                                            {#if el.tagName != "TEI-PERSNAME"}
-                                                {@html el.innerHTML}
-                                            {:else}
-                                                <div
-                                                    class="text-sm text-secondary-600 italic mt-4 pr-4 text-right"
-                                                >
-                                                    <a
-                                                        href="{base}/people/{el.getAttribute(
-                                                            'corresp',
-                                                        )}"
-                                                        class="hover:anchor"
-                                                        target="_blank"
-                                                        >— {@html el.innerHTML}</a
-                                                    >
-                                                </div>
-                                            {/if}
-                                        {/each}
-                                    </div>
-                                    <!-- Only adds the divider if there are more than one readings and it's not the last one -->
-                                    {#if altReadings.length > 1}
-                                        {#if i < altReadings.length - 1}
-                                            <TextDivider
-                                                fillColour="#5E9DB5"
-                                                class="mb-4"
-                                            />
-                                        {/if}
-                                    {/if}
-                                {/each}
+                            <div class="mt-2" id="note-content">
+                                
                             </div>
                         </div>
                     </div>
@@ -323,4 +366,5 @@
             </div>
         </div>
     </div>
+    <TextDivider fillColour="#5E9DB5" class="mb-4 text-divider hidden"/>
 {/if}

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -227,33 +227,40 @@
 
     function applyVariationStyles(app) {
         for (const child of app.children) {
-            // removes any previous styling for the element
-            cleanVariationStyles(child);
+            
 
             // restores baseline styling for elements inside apps
             // child.classList = "";
-            if (app.getAttribute("subtype") === "add") {
-                child.classList.add("bg-success-200", "hover:bg-success-400");
-            } else if (app.getAttribute("subtype") === "del") {
-                child.classList.add("bg-error-200", "hover:bg-error-400");
-            } else {
-                child.classList.add(
-                    "bg-secondary-200",
-                    "hover:bg-secondary-400",
-                );
-            }
 
-            // adds common styles from the variationCommonStyles array
-            for (const style of variationCommonStyles) {
-                child.classList.add(style);
-            }
-
-            // adds messages for empty elements
             if (child.tagName === "TEI-LEM") {
+                // removes any previous styling for the element
+                cleanVariationStyles(child);
+                
+                // adds messages for empty elements
                 if (child.hasAttribute("data-empty")) {
                     child.innerHTML = "[+1609]";
                     child.classList.remove("hidden");
                 }
+                
+                if (app.getAttribute("subtype") === "add") {
+                    child.classList.add(
+                        "bg-success-200",
+                        "hover:bg-success-400",
+                    );
+                } else if (app.getAttribute("subtype") === "del") {
+                    child.classList.add("bg-error-200", "hover:bg-error-400");
+                } else {
+                    child.classList.add(
+                        "bg-secondary-200",
+                        "hover:bg-secondary-400",
+                    );
+                }
+
+                // adds common styles from the variationCommonStyles array
+                for (const style of variationCommonStyles) {
+                    child.classList.add(style);
+                }
+
             } else if (child.tagName === "TEI-RDG") {
                 if (child.hasAttribute("data-empty")) {
                     child.innerHTML = "[Does not exist in 1609]";

--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -52,7 +52,6 @@ export let teiBehaviours = {
         },
         "gloss": [
             ["[rend='italic']", function (elt) {
-                console.log('gloss')
                 addTailwindClasslist(elt, "italic")
             }
             ]

--- a/tests/E2E/essential/ViewLit.test.js
+++ b/tests/E2E/essential/ViewLit.test.js
@@ -64,14 +64,14 @@ test.describe('Transcription page has TEI content', () => {
         const container = page.getByTestId('TEI-container');
         await Promise.all([
             container.waitFor('visible'),
-            expect(page.getByText('Feminine Monarchie', { exact: true })).toBeVisible()
+            expect(page.getByText('Feminine Monarchie:', { exact: true })).toBeVisible()
         ]);
     });
 
     // Test that tei-body is visible
     test('Expect that the literature view contains TEI-body after the page loads', async ({ page }) => {
         await expect(page).toHaveURL('/literature/transcription');
-        const teiText = page.getByText('Feminine Monarchie', { exact: true });
+        const teiText = page.getByText('Feminine Monarchie:', { exact: true });
         await Promise.all([
             teiText.waitFor('visible'),
             // locating by css selectors is considered bad practice, but there's no other way (currently) of locating this element; for a simple existence check, it's fine
@@ -82,7 +82,7 @@ test.describe('Transcription page has TEI content', () => {
     // Test that tei-header is not visible
     test('Expect that the literature view contains TEI-header after the page loads, but that this is not visible', async ({ page }) => {
         await expect(page).toHaveURL('/literature/transcription');
-        const teiText = page.getByText('Feminine Monarchie', { exact: true });
+        const teiText = page.getByText('Feminine Monarchie:', { exact: true });
         await Promise.all([
             teiText.waitFor('visible'),
             // locating by css selectors is considered bad practice, but there's no other way (currently) of locating this element; for a simple existence check, it's fine


### PR DESCRIPTION
## Description

Changes the way in which editorial notes and collation alternatives are shown. Instead of copying the contents of each element (rdg or note) as elt.innerHTML into a new one, it copies them as elements themselves so that, if there is any particular encoding (like a <term>) it will be correctly rendered in the note modal.

Can potentially break stuff, but everything seems to work ok so far.

Fixes #191 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated tests

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes