### PR TITLE
Tiagosousagarcia/issue125

### DIFF
--- a/src/lib/DataSelector.svelte
+++ b/src/lib/DataSelector.svelte
@@ -126,7 +126,7 @@
 <svelte:window bind:innerWidth={width} bind:scrollY={scrollValue}/>
 
 {#key dataViewerState}
-    <form class="sticky top-0 md:static md:z-auto w-full bg-primary-400 py-6">
+    <div class="sticky top-0 md:static md:z-auto w-full bg-primary-400 py-6">
         {#if smallScreen}
             <button
                 onclick={toggleBar}
@@ -188,5 +188,5 @@
                 </div>
             </div>
         {/if}
-    </form>
+    </div>
 {/key}

--- a/src/lib/IIIFViewer.svelte
+++ b/src/lib/IIIFViewer.svelte
@@ -10,7 +10,6 @@
     // This needs to be imported only on the browser, otherwise it will generate an error
     // import "tify";
     import "tify/dist/tify.css";
-    import { dataViewerState } from "../stores/dataViewer.svelte";
 
     let iiif = $state(undefined);
     let changeHere = false;
@@ -38,7 +37,7 @@
                 }
             });
         } catch (e) {
-            console.warn("tify is not ready");
+            console.warn("tify is not ready during removing header");
         }
     }
 
@@ -65,7 +64,7 @@
                 barHeader.classList = "";
             });
         } catch (e) {
-            console.warn("tify is not ready");
+            console.warn("tify is not ready during replacing page select button");
         }
     }
 
@@ -122,22 +121,26 @@
                 );
             });
         } catch (e) {
-            console.warn("tify is not ready", e);
+            console.warn("tify is not ready during adding listeners", e);
         }
     }
 
     async function changePage(pageNumber = teiViewerState.currentPage) {
-        try {
-            teiViewerState.scrolling = true;
-            await iiif.ready.then(() => {
+        
+        teiViewerState.scrolling = true;
+        await iiif.ready
+        .then(
+            () => {
                 iiif.setPage([parseInt(pageNumber)]);
                 teiViewerState.currentPage = parseInt(pageNumber);
                 changeHere = false;
                 teiViewerState.scrolling = false;
-            });
-        } catch (e) {
-            console.warn("tify is not ready");
-        }
+            },
+            (e) => {
+                console.error("Error setting page", e);
+                teiViewerState.scrolling = false;
+                changeHere = false;
+            })
     }
 
     onMount(async () => {

--- a/src/lib/IIIFViewer.svelte
+++ b/src/lib/IIIFViewer.svelte
@@ -173,15 +173,16 @@
         }
     });
 
-    $effect(() => {
+    $effect(async () => {
         if (teiViewerState.updateIIIF) {
             // set currentSignature to the signature of the current page in the viewer
-            changePage(
+            await changePage(
                 teiViewerState.signatures.indexOf(
                     teiViewerState.currentSignature,
                 ) + parseInt(startPage),
-            );
-            teiViewerState.updateIIIF = false;
+            ).then(() => {
+                teiViewerState.updateIIIF = false;
+            });
         }
     });
 

--- a/src/lib/PageSelectButton.svelte
+++ b/src/lib/PageSelectButton.svelte
@@ -1,6 +1,7 @@
 <script>
     let { currentPage, newPage } = $props();
 </script>
+
 <div id="custom-page-select-button" class="flex self-center">
 <input class="max-w-16 text-center rounded-l-md"
     min="0"

--- a/src/lib/TEISimple.svelte
+++ b/src/lib/TEISimple.svelte
@@ -18,7 +18,9 @@
     import { teiBehaviours } from "../utils/teiBehaviours";
 
     import { teiViewerState } from "../stores/teiViewer.svelte";
-    import { isElementVisibleUntracked } from "../utils/generalHelpers";
+    import { findLastMilestoneBefore, isElementVisibleUntracked } from "../utils/generalHelpers";
+    import { page } from "$app/state";
+    import { replaceState } from "$app/navigation";
 
     let { transcriptionData = "", statusCheck } = $props();
 
@@ -38,7 +40,9 @@
         }
 
         // inserts TEI content
-        var cetei = new CETEI();
+        var cetei = new CETEI(
+            {ignoreFragmentId: true}
+        );
         cetei.addBehaviors(teiBehaviours);
         await cetei
             .getHTML5(path, function (data) {
@@ -249,6 +253,69 @@
         }
     }
 
+    function internalLinkScroll(eltId) {
+        const startingSigs = {
+            titlepage: "¶2r",
+            preface: "¶3r",
+            dedication: "A1v",
+            contents: "A2r",
+            ch1: "B1r",
+            ch2: "D4r",
+            ch3: "E4r",
+            ch4: "H1r",
+            ch5: "I3r",
+            ch6: "N3v",
+            ch7: "P4r",
+            ch8: "S2r",
+            ch9: "T1r",
+            ch10: "T2v",
+        };
+
+        // gets the target of the link
+        let targetEl = document.querySelector(eltId);
+        // checks to see if the target is a chapter
+        if (Object.keys(startingSigs).includes(targetEl.id)) {
+            // if it is, uses the object to find the corresponding signature;
+            teiViewerState.currentSignature =
+                startingSigs[targetEl.id];
+            scrollToPB(
+                startingSigs[targetEl.id],
+            );
+            teiViewerState.updateIIIF = true;
+            teiViewerState.updateSection = true;
+        } else {
+            // if it isn't, tries to find the pb that immediately precedes it
+            let pb = findLastMilestoneBefore(targetEl, "tei-pb");
+            if (pb) {
+                teiViewerState.currentSignature = pb.getAttribute("n");
+                scrollToPB(pb.getAttribute("n"));
+                teiViewerState.updateIIIF = true;
+                teiViewerState.updateSection = true;
+                targetEl.scrollIntoView();
+            } else {
+                console.warn("No pb found for target element");
+            }
+        }
+    }
+
+    function internalLinkScrollHandler(e) {
+        // prevents the default action of the link
+        e.preventDefault();
+        internalLinkScroll(this.getAttribute("href"));
+    }
+
+    function navigateToHashFromUrl() {
+        // gets the intended hash from the url
+        const destHash = page.url.hash;
+                
+        // resets the hash to prevent the page from jumping 
+        // to the element when the page loads
+        if (loaded) {
+            replaceState('', page.state)
+            internalLinkScroll(destHash); 
+        }
+    }
+
     onMount(async () => {
         try {
             if (path === "" || path === undefined) {
@@ -288,10 +355,10 @@
                 }
 
                 // Might need to adjust the rate ot throttling later -- currently hard to tell because the iiif document is taking a while
-                const throttledScrollHandler = _.throttle(
-                    turnPageOnScroll,
-                    300,
-                );
+                // const throttledScrollHandler = _.throttle(
+                //     turnPageOnScroll,
+                //     300,
+                // );
 
                 const debouncedScrollHandler = _.debounce(
                     turnPageOnScroll,
@@ -302,13 +369,33 @@
                     .querySelector("[data-testid='transcription']")
                     .addEventListener("scroll", debouncedScrollHandler);
                 loaded = true;
+
+                // adds onclick event to each element with data-type="internal-link"
+                const internalLinks = document.querySelectorAll(
+                    "[data-type='internalLink']",
+                );
+                internalLinks.forEach((link) => {
+                    link.addEventListener("click", internalLinkScrollHandler);
+                });
             });
+
+            loaded = true;
+
+            if (page.url.hash) {
+                navigateToHashFromUrl();
+            }
         } catch (err) {
             error = err.toString();
             loaded = false;
             return;
         }
     });
+
+    $effect(() => {
+        if (page.url.hash && loaded) {
+            navigateToHashFromUrl();
+        }
+    })
 </script>
 
 <div id="TEI-container" data-testid="TEI-container">

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -68,18 +68,18 @@
             const firstSigs = {
                 "¶2r": "titlepage",
                 "¶3r": "preface",
-                A1v: "dedication",
-                A2r: "contents",
-                B1r: "ch1",
-                D4r: "ch2",
-                E4r: "ch3",
-                H1r: "ch4",
-                I3r: "ch5",
-                N3v: "ch6",
-                P4r: "ch7",
-                S2r: "ch8",
-                T1r: "ch9",
-                T2v: "ch10",
+                "A1v": "dedication",
+                "A2r": "contents",
+                "B1r": "ch1",
+                "D4r": "ch2",
+                "E4r": "ch3",
+                "H1r": "ch4",
+                "I3r": "ch5",
+                "N3v": "ch6",
+                "P4r": "ch7",
+                "S2r": "ch8",
+                "T1r": "ch9",
+                "T2v": "ch10",
             };
 
             if (dataViewerState.activeView === "facsimile") {
@@ -197,6 +197,7 @@
     import transcriptionData from "../routes/(sections)/literature/transcription/transcriptionData.json";
     import { findLastMilestoneBefore } from "../utils/generalHelpers";
     import { isElementVisibleInViewport } from "../utils/teiBehavioursHelper";
+    import { replaceState } from "$app/navigation";
 
     function cleanVariationStyles(el) {
         // removes any bg styling for the element
@@ -588,24 +589,7 @@
         ready = true;
     });
 
-    $effect(() => {
-        if (page.url.hash) {
-            console.log('linked to page', page.url.hash);
-            if (page.url.hash === '#ch4'){
-                // at some point between this and updating IIIF, current page becomes NaN -- can't figure out why
-                teiViewerState.currentSignature = "H1r";
-                teiViewerState.updateIIIF = true;
-                teiViewerState.updateSection = true;
-            }
-        } else {
-            console.log('no direct link');
-        }
-    })
-
-
 </script>
-
-{@debug teiViewerState}
 
 <svelte:window bind:innerWidth={windowSize} />
 

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -590,10 +590,12 @@
 
     $effect(() => {
         if (page.url.hash) {
+            console.log('linked to page', page.url.hash);
             if (page.url.hash === '#ch4'){
                 // at some point between this and updating IIIF, current page becomes NaN -- can't figure out why
                 teiViewerState.currentSignature = "H1r";
                 teiViewerState.updateIIIF = true;
+                teiViewerState.updateSection = true;
             }
         } else {
             console.log('no direct link');

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -1,4 +1,6 @@
 <script>
+    import {page} from "$app/state";
+
     import TeiSimple from "./TEISimple.svelte";
     import IiifViewer from "./IIIFViewer.svelte";
     import PdfViewer from "./PdfViewer.svelte";
@@ -585,7 +587,23 @@
 
         ready = true;
     });
+
+    $effect(() => {
+        if (page.url.hash) {
+            if (page.url.hash === '#ch4'){
+                // at some point between this and updating IIIF, current page becomes NaN -- can't figure out why
+                teiViewerState.currentSignature = "H1r";
+                teiViewerState.updateIIIF = true;
+            }
+        } else {
+            console.log('no direct link');
+        }
+    })
+
+
 </script>
+
+{@debug teiViewerState}
 
 <svelte:window bind:innerWidth={windowSize} />
 

--- a/src/utils/generalHelpers.js
+++ b/src/utils/generalHelpers.js
@@ -256,7 +256,7 @@ export function findFirstDescendantByTagName(parentElement, tagName) {
 // Only provides current status, does not observe until it is in view
 export function isElementVisibleUntracked(elt, callback) {
   if (!elt) {
-      console.warn('Element is not provided');
+      console.warn('Element is not provided for visibility check in isElementVisibleUntracked');
       return;
   }
   const observer = new IntersectionObserver((entries, observer) => {

--- a/src/utils/teiBehaviours.js
+++ b/src/utils/teiBehaviours.js
@@ -145,9 +145,10 @@ export let teiBehaviours = {
         "ptr": [
             ["tei-item>tei-ptr", function (elt) {
                 let link = document.createElement('a');
+                link.setAttribute('data-href', elt.getAttribute('target'));
+                link.setAttribute('href', elt.getAttribute('target'));
+                link.setAttribute('data-type', 'internalLink');
                 link.classList.add('text-secondary-500', 'hover:text-secondary-900', 'hover:cursor-pointer', 'hover:underline');
-
-                link.href = elt.getAttribute('target');
 
                 wrapChildren(elt.parentElement, link);
             }]
@@ -189,8 +190,16 @@ export let teiBehaviours = {
                     window.dispatchEvent(event);
                 }
             } else {
+                // creates a fake link instead
                 var link = document.createElement('a');
                 link.classList.add('anchor');
+
+                if (elt.getAttribute('target')[0] === '#' && elt.getAttribute('target').length > 1) {
+                    // adds these types only if it is an internal link to the same page
+                    link.setAttribute('data-href', elt.getAttribute('target'));
+                    link.setAttribute('data-type', 'internalLink');
+                }
+                
                 link.href = elt.getAttribute('target');
                 if (sup) {
                     const supEl = document.createElement('sup');
@@ -199,6 +208,7 @@ export let teiBehaviours = {
                 } else {
                     link.innerHTML = elt.innerHTML;
                 }
+
 
                 // highlights when hovered and finds the corresponding element to highlight
                 link.addEventListener('mouseover', function () {

--- a/src/utils/teiBehavioursHelper.js
+++ b/src/utils/teiBehavioursHelper.js
@@ -44,7 +44,7 @@ export function getElementRect(elt) {
 
 export function isElementVisibleInViewport(elt, callback) {
     if (!elt) {
-        console.warn('Element is not provided');
+        console.warn('Element is not provided for visibility check');
         return;
     }
 


### PR DESCRIPTION
## Description

Fixes the ability to navigate with internal links and keep the auto page turning available;

Changes the element of the data controls to a div (because form was falling back to svelte form actions and introducing undesirable parameters to the url occasionally)

One bug remains, if the user changes the address to navigate to a hash while on the transcription page, the iiif viewer will not automatically update (instead showing page 1)

Fixes #125 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes