### PR TITLE
Establishes basic sync for 1609

### DIFF
--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -1,6 +1,4 @@
 <script>
-    import {page} from "$app/state";
-
     import TeiSimple from "./TEISimple.svelte";
     import IiifViewer from "./IIIFViewer.svelte";
     import PdfViewer from "./PdfViewer.svelte";
@@ -34,10 +32,31 @@
     let showModal = $state(false);
     let modalElement = $state(null);
 
+
     import { dataViewerState } from "../stores/dataViewer.svelte";
     import { teiViewerState } from "../stores/teiViewer.svelte";
 
     import { onMount } from "svelte";
+
+    
+    // needed to prevent the effect to reseting the state on mount
+    let currentDataset = '';
+    $effect(() => {
+        if (ready && 
+            dataViewerState.activeDataset &&
+            currentDataset &&
+            dataViewerState.activeDataset !== currentDataset) {
+            // resets state:
+            teiViewerState.signatures = [];
+            teiViewerState.currentSignature = undefined;
+            teiViewerState.currentSection = undefined;
+            teiViewerState.currentPage = undefined;
+            teiViewerState.scrolling = false;
+            teiViewerState.updateIIIF = false;
+            teiViewerState.updateTEI = false;
+            teiViewerState.updateSection = false;
+        }
+    });
 
     $effect(() => {
         changeVariationDetail(dataViewerState.variationDetail);
@@ -51,7 +70,6 @@
         toggleBothViewOption(smallScreen);
     });
 
-    // FIRING WHEN IT SHOULDN'T (IE, CHANGING TO CH 5 THEN SCROLLING UP A PAGE)
     $effect(() => {
         skipToSection(dataViewerState.activeNavigator);
     });
@@ -197,7 +215,8 @@
     import transcriptionData from "../routes/(sections)/literature/transcription/transcriptionData.json";
     import { findLastMilestoneBefore } from "../utils/generalHelpers";
     import { isElementVisibleInViewport } from "../utils/teiBehavioursHelper";
-    import { replaceState } from "$app/navigation";
+    import { derived } from "svelte/store";
+    import { updateSession } from "@sentry/core";
 
     function cleanVariationStyles(el) {
         // removes any bg styling for the element
@@ -530,9 +549,14 @@
     }
 
     onMount(() => {
+        ready = false;
+        
         if (dataViewerState.activeDataset === 0) {
             dataViewerState.activeDataset = "1623";
         }
+
+        // necessary to reset the state after changing datasets
+        currentDataset = dataViewerState.activeDataset;
 
         if (
             !["facsimile", "transcription", "both"].includes(


### PR DESCRIPTION
## Description

Resets the state values that were being carried over to 1609 and making it impossible to correctly sync transcription and facsimile; other than edge-cases (hard-coded for 1623), it works fine

Fixes #210 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
