### PR TITLE
Tiagosousagarcia/issue183

### DIFF
--- a/src/lib/DataSelector.svelte
+++ b/src/lib/DataSelector.svelte
@@ -123,6 +123,8 @@
 
 </script>
 
+{@debug dataViewerState}
+
 <svelte:window bind:innerWidth={width} bind:scrollY={scrollValue}/>
 
 {#key dataViewerState}

--- a/src/lib/DataViewPanel.svelte
+++ b/src/lib/DataViewPanel.svelte
@@ -15,10 +15,15 @@
     import InjectMD from "./InjectMD.svelte";
     import { getGroups } from "../utils/sciDataHelper";
 
-    import {dataViewerState} from "../stores/dataViewer.svelte";
+    import { dataViewerState } from "../stores/dataViewer.svelte";
     import GraphControls from "./GraphControls.svelte";
+    import { derived } from "svelte/store";
 
-    let {dataset} = $props();
+    let { datasetArray } = $props();
+
+    let dataset = $derived.by(() => {
+        return datasetArray[dataViewerState.activeDataset];
+    });
 
     let selected = $state("All");
     let loaded = $state(false);
@@ -26,63 +31,73 @@
     // Error codes
     // 0 = all good
     // 1 = No data received
-    let error = $state(0);
+    let error = $derived.by(() => {
+        if (dataset) {
+            return 0;
+        } else {
+            return 1;
+        }
+    });
 
     onMount(() => {
         if (!dataset) {
-            error = 1;
+            dataViewerState.activeDataset = 0;
+            dataViewerState.activeView = "details";
         }
         loaded = true;
-    })
-
+    });
 </script>
 
-{#if error == 0 && loaded}
-    <div class="md:w-2/3 m-auto" data-testid="data-content-div">
-        {#if dataViewerState.activeView === "data"}
-            <GraphControls
-            >
-                <GroupSelector
-                    groups={getGroups("Treatment group", dataset.data)}
-                    name={"Treatment group"}
-                    bind:selected
-                />
-            </GraphControls>
+{#key dataViewerState.activeDataset}
+    {#if error == 0 && loaded}
+        <div class="md:w-2/3 m-auto" data-testid="data-content-div">
+            {#if dataViewerState.activeView === "data"}
+                <GraphControls>
+                    <GroupSelector
+                        groups={getGroups("Treatment group", dataset.data)}
+                        name={"Treatment group"}
+                        bind:selected
+                    />
+                </GraphControls>
 
-            <RawDataTable
-                tableObject={{ data: dataset.data, columns: dataset.columns }}
-                {selected}
-            />
-        {:else if dataViewerState.activeView === "summary"}
-            <GraphControls>
-                <GroupSelector
-                groups={getGroups("Treatment group", dataset.data)}
-                name={"Treatment group"}
-                bind:selected
+                <RawDataTable
+                    tableObject={{
+                        data: dataset.data,
+                        columns: dataset.columns,
+                    }}
+                    {selected}
                 />
-            </GraphControls>
-            <RawDataTable
-                tableObject={{
-                    data: dataset.summaryData,
-                    columns: dataset.summaryColumns,
-                }}
-                {selected}
-            />
-        {:else if dataViewerState.activeView === "visualisation"}
-            <DataViz
-                dataObject={{
-                    data: dataset.summaryData,
-                    labels: dataset.summaryColumns,
-                }}
-                bind:selected
-                name={dataset.desc.metadata.title}
-                rawData={dataset.data}
-                groups={getGroups("Treatment group", dataset.data)}
-            />
-        {:else if dataViewerState.activeView === "details"}
-            <InjectMD content={dataset.desc.content} />
-        {/if}
-    </div>
-{:else if error == 1 && loaded}
-    <p class="error-message">Error: no data available</p>
-{/if}
+            {:else if dataViewerState.activeView === "summary"}
+                <GraphControls>
+                    <GroupSelector
+                        groups={getGroups("Treatment group", dataset.data)}
+                        name={"Treatment group"}
+                        bind:selected
+                    />
+                </GraphControls>
+                <RawDataTable
+                    tableObject={{
+                        data: dataset.summaryData,
+                        columns: dataset.summaryColumns,
+                    }}
+                    {selected}
+                />
+            {:else if dataViewerState.activeView === "visualisation"}
+                <DataViz
+                    dataObject={{
+                        data: dataset.summaryData,
+                        labels: dataset.summaryColumns,
+                    }}
+                    bind:selected
+                    name={dataset.desc.metadata.title}
+                    rawData={dataset.data}
+                    groups={getGroups("Treatment group", dataset.data)}
+                />
+            {:else if dataViewerState.activeView === "details"}
+                <InjectMD content={dataset.desc.content} />
+            {/if}
+        </div>
+    {:else if error == 1 && loaded}
+        <p class="error-message">Error: no data available</p>
+    {/if}
+{/key}

--- a/src/lib/DataViewPanel.svelte
+++ b/src/lib/DataViewPanel.svelte
@@ -40,7 +40,7 @@
     });
 
     onMount(() => {
-        if (!dataset) {
+        if (!dataset && datasetArray) {
             dataViewerState.activeDataset = 0;
             dataViewerState.activeView = "details";
         }

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -551,8 +551,10 @@
     onMount(() => {
         ready = false;
         
-        if (dataViewerState.activeDataset === 0) {
+        // if activeDataset contains a value from the science view, reset to 1623
+        if (!["1623", "1609"].includes(dataViewerState.activeDataset)) {
             dataViewerState.activeDataset = "1623";
+            dataViewerState.activeView = "both";
         }
 
         // necessary to reset the state after changing datasets

--- a/src/routes/(sections)/science/datasets/datasets.md
+++ b/src/routes/(sections)/science/datasets/datasets.md
@@ -49,6 +49,6 @@ layout: false
 </TypographyLead>
 
 {#await data.datasets then datasets}
-    <DataViewPanel dataset = {datasets[dataViewerState.activeDataset]}/>
+    <DataViewPanel datasetArray = {datasets}/>
 {/await}
 

--- a/tests/components/DataViewPanel.test.js
+++ b/tests/components/DataViewPanel.test.js
@@ -27,18 +27,18 @@ describe ('Load and display data view panel', () => {
     afterEach(() => cleanup());
 
     it('should be able to mount the component without any data', () => {
-        const container = render(DataViewPanel, {dataset: ''});
+        const container = render(DataViewPanel, {datasetArray: []});
         expect(container).toBeTruthy();
     });
 
     it('should display an error message if no data has been passed', async () => {
-        render(DataViewPanel, {dataset: ''});
+        render(DataViewPanel, {datasetArray: []});
         const errorMessage = await screen.findByText('Error: no data available', {exact: false})
         expect(errorMessage).toBeTruthy();
     });
 
     it('should be able to display the data when the required data is passed', async () => {
-        render(DataViewPanel, {dataset: datasets[0]});
+        render(DataViewPanel, {datasetArray: datasets});
         const container = screen.getByTestId('data-content-div');
         expect(container).toBeTruthy();
     });


### PR DESCRIPTION
## Description

Changes the logic of `DataViewPanel.svelte` slightly to a) expect an array of datasets and b) change values to defaults if the state contains values from the transcription pages;

Also fixes a number of small bugs that resulted from users switching between  science datset views and transcription views.

Fixes #183 #178 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated  testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.

<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
