### PR TITLE
this seems to work now -- maybe there was a  cache problem when I tho…

### DIFF
--- a/src/lib/NoteModal.svelte
+++ b/src/lib/NoteModal.svelte
@@ -45,7 +45,6 @@
                     let singNoteDiv = document.createElement("div");
                     singNoteDiv.classList.add("mb-4");
                     singNoteDiv.classList.add("single-note");
-                    // THIS IS REMOVING TOO MANY NOTES IF USED REPEATEDLY
                     if (ids[i]) {
                         // checks to see if the id exists in the notesDiv
                         const existingNote = document.getElementById(`modal-${ids[i]}`);


### PR DESCRIPTION
…ught there was an error

## Description

Problem was happening because the state variable that collects the editorial notes was being updated, and the JS function that places the notes on the screen appends the notes to the existing list (rather than replacing the entire note div -- this is too allow various types of notes to be displayed simultaneously); notes now carry an id, before appending a note to the div the function looks to see if the ID already exists, and if so, it removes the old note with the id before appending the new updated list of notes.

Fixes #229 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing, firefox and chrome

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

