### PR TITLE
corrects bug --  the element was being mistakenly removed before adding

### DIFF
--- a/src/lib/NoteModal.svelte
+++ b/src/lib/NoteModal.svelte
@@ -39,7 +39,7 @@
             let ids = [];
             for (const [i, reading] of altReadings.entries()) {
                 // checks to see if the last element is an object
-                if (typeof reading[reading.length - 1] === "object") {
+                if (typeof reading[reading.length - 1] === "object" && Object.keys(reading[reading.length - 1]).includes("id")) {
                     // if it is an object, add it to ids dictionary
                     ids[i] = reading[reading.length - 1].id;
                     //pop it from the reading array
@@ -64,7 +64,7 @@
 
                     singNoteDiv.setAttribute("id", `modal-${ids[i]}`);
                 }
-
+                
                 for (const elRead of reading) {
                     if (elRead.tagName != "TEI-PERSNAME") {
                         // check to see if it is not a text node and not hidden:


### PR DESCRIPTION
## Description

Removes the bug that was preventing variation from being displayed correctly. The bug was actually introduced by #233 

When building the array of ids (which are only used for notes), the function was simply removing the last element of the altReadings array without checking whether the element was indeed an id object; refactor to only do the poping if the last element is an object of ids

Fixes #248 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes