### PR TITLE
adjusted paths to cell backgrounds

### DIFF
--- a/src/lib/Cell.svelte
+++ b/src/lib/Cell.svelte
@@ -41,7 +41,7 @@
     data-testid = {testid}>
         <InternalLink {link} class="group">
             <div
-                style="background-image: url(crops/{backgroundImage}); background-position: center;"
+                style="background-image: url({backgroundImage}); background-position: center;"
                 class="clip-path-hexagon absolute w-[7.75rem] h-[6.875rem] top-[0.438rem] left-[0.438rem] bg-black/50 bg-blend-multiply group-hover:bg-black/75 transition-all ease-in-out duration-300 motion-reduce:transition-none flex justify-center items-center"
             >
                 <p class="size-fit text-white md:text-xl">
@@ -55,7 +55,7 @@
     <div class="" data-testid = {testid}>
         <InternalLink {link} class="group">
         <div
-            style="background-image: url(crops/{backgroundImage}); background-position: center;"
+            style="background-image: url({backgroundImage}); background-position: center;"
             class="clip-path-hexagonBorder w-[8.563rem] h-[7.688rem] bg-secondary-50/75 bg-blend-overlay group-hover:bg-secondary-900/75 transition-all ease-in-out duration-300 motion-reduce:transition-none flex justify-center items-center">
                 <p class="invisible size-fit no-underline text-white text-sm text-center group-hover:visible transition-all ease-in-out duration-300 motion-reduce:transition-none">
                     {text}

--- a/src/lib/Hive.svelte
+++ b/src/lib/Hive.svelte
@@ -24,14 +24,14 @@
       <Cell
         type="article"
         link={spotlightArray[0]["link"]}
-        backgroundImage="{base}/{spotlightArray[0]['img']}"
+        backgroundImage="{base}/crops/{spotlightArray[0]['img']}"
         text={spotlightArray[0]["lead"]}
       />
       <Cell type="empty" />
       <Cell
         type="article"
         link={spotlightArray[1]["link"]}
-        backgroundImage="{base}/{spotlightArray[1]['img']}"
+        backgroundImage="{base}/crops/{spotlightArray[1]['img']}"
         text={spotlightArray[1]["lead"]}
       />
       <Cell type="empty" />
@@ -60,14 +60,14 @@
       <Cell
         type="article"
         link={spotlightArray[2]["link"]}
-        backgroundImage="{base}/{spotlightArray[2]['img']}"
+        backgroundImage="{base}/crops/{spotlightArray[2]['img']}"
         text={spotlightArray[2]["lead"]}
       />
       <Cell type="empty" />
       <Cell
         type="article"
         link={spotlightArray[3]["link"]}
-        backgroundImage="{base}/{spotlightArray[3]['img']}"
+        backgroundImage="{base}/crops/{spotlightArray[3]['img']}"
         text={spotlightArray[3]["lead"]}
       />
       <Cell type="empty" />
@@ -77,7 +77,7 @@
       <Cell
         type="article"
         link={spotlightArray[4]["link"]}
-        backgroundImage="{base}/{spotlightArray[4]['img']}"
+        backgroundImage="{base}/crops/{spotlightArray[4]['img']}"
         text={spotlightArray[4]["lead"]}
       />
       <Cell type="empty" />
@@ -103,7 +103,7 @@
       <Cell
         type="article"
         link={spotlightArray[5]["link"]}
-        backgroundImage="{base}/{spotlightArray[5]['img']}"
+        backgroundImage="{base}/crops/{spotlightArray[5]['img']}"
         text={spotlightArray[5]["lead"]}
       />
       <Cell type="empty" />
@@ -117,7 +117,7 @@
       <Cell
         type="article"
         link={spotlightArray[6]["link"]}
-        backgroundImage="{base}/{spotlightArray[6]['img']}"
+        backgroundImage="{base}/crops/{spotlightArray[6]['img']}"
         text={spotlightArray[6]["lead"]}
       />
     </div>
@@ -142,7 +142,7 @@
       <Cell
         type="article"
         link={spotlightArray[0].link}
-        backgroundImage="{base}/{spotlightArray[0].img}"
+        backgroundImage="{base}/crops/{spotlightArray[0].img}"
         text={spotlightArray[0].lead}
       />
     </div>
@@ -201,7 +201,7 @@
       <Cell
         type="article"
         link={spotlightArray[1].link}
-        backgroundImage="{base}/{spotlightArray[1].img}"
+        backgroundImage="{base}/crops/{spotlightArray[1].img}"
         text={spotlightArray[1].lead}
       />
     </div>


### PR DESCRIPTION
## Description

corrects the paths to the images used in the cell backgrounds (failing on build and deploy). relative path is constructed in the `Hive` component, `Cell` makes no changes to path

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes