### PR TITLE
Tiagosousagarcia/issue281

### DIFF
--- a/src/lib/DataSelectorControls/DataNavigator.svelte
+++ b/src/lib/DataSelectorControls/DataNavigator.svelte
@@ -2,7 +2,7 @@
     import { onMount } from "svelte";
 
     // listIndex should be an array of arrays in which the first value is the display name and the second value is the xml:id
-    let { options, valueChange, currentSelected } = $props();
+    let { options, valueChange, currentSelected, disabled = false } = $props();
 
     let selected = $state(0);
     let validValues = [];
@@ -36,7 +36,7 @@
 
 {#if options != undefined}
     <div
-        class="flex text-4xl md:text-5xl justify-center items-center text-gray-600 w-48"
+        class="flex text-4xl md:text-5xl justify-center items-center text-gray-600 w-48 {disabled ? 'opacity-50 cursor-not-allowed' : ''}"
     >
         <button
             class="hover:font-bold hover:cursor-pointer hover:text-black transition-all ease-in-out duration-200 motion-reduce:transition-none"
@@ -47,7 +47,7 @@
                 selected = options.listIndex[currentlySelectedIndex - 1][1];
                 changeSelected();
             }}
-            disabled={selected == options.listIndex[0][1]} aria-label="Previous section"
+            disabled={!disabled ? selected == options.listIndex[0][1] : disabled} aria-label="Previous section"
         >
             <svg
                 class="size-[32px] fill-secondary-400 hover:fill-secondary-800 rotate-180"
@@ -71,6 +71,7 @@
             class="select text-lg text-center md:text-xl bg-transparent border-none rounded-lg max-w-fit font-pfdisplay hover:font-bold hover:cursor-pointer transition-all ease-in-out duration-200 motion-reduce:transition-none text-black w-40"
             onchange={changeSelected}
             id="navigator-select"
+            disabled={disabled}
         >
             {#each options.listIndex as section}
                 <option value={section[1]}>{section[0]}</option>
@@ -85,8 +86,7 @@
                 selected = options.listIndex[currentlySelectedIndex + 1][1];
                 changeSelected();
             }}
-            disabled={selected ==
-                options.listIndex[options.listIndex.length - 1][1]} aria-label="Next section"
+            disabled={!disabled ? selected == options.listIndex[options.listIndex.length - 1][1] : disabled} aria-label="Next section"
         >
             <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
             <svg

--- a/src/lib/DataSelectorControls/DataNavigator.svelte
+++ b/src/lib/DataSelectorControls/DataNavigator.svelte
@@ -2,10 +2,18 @@
     import { onMount } from "svelte";
 
     // listIndex should be an array of arrays in which the first value is the display name and the second value is the xml:id
-    let { options, valueChange, currentSelected, disabled = false } = $props();
+    let { options, valueChange, currentSelected } = $props();
 
     let selected = $state(0);
     let validValues = [];
+    
+    let disabled = $derived.by(() => {
+        if (currentSelected === 'disabled') {
+            return true;
+        } else {
+            return false;
+        }
+    });
 
     onMount(() => {
 

--- a/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
+++ b/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
@@ -13,7 +13,7 @@
     import { onMount } from 'svelte';
 
 
-    let {options, valueChange, currentSelected} = $props();
+    let {options, valueChange, currentSelected, disabled = false} = $props();
     let radioValue = $state(undefined);
 
     onMount(() => {
@@ -31,8 +31,9 @@
 
 </script>
 
+{@debug radioValue}
 
-<div class="flex flex-col gap-2 font-light text-xs md:text-sm" data-testid="radio-group-{options.label}">
+<div class="flex flex-col gap-2 font-light text-xs md:text-sm  {disabled ? 'opacity-50 cursor-not-allowed' : ''}" data-testid="radio-group-{options.label}">
     <label for="radio-group-{options.label}" class="hidden md:block font-light text-sm pl-4"
         >{options.label}</label
     >
@@ -45,15 +46,15 @@
     >
         {#key options}
         {#each Object.entries(options.values) as [label, value]}
-            <RadioItem bind:group={radioValue} name={label} value={value} onchange={() => valueChange({origin: options.label, newValue: value})} id="{makeHtmlId(options.label)}-{makeHtmlId(value)}-button"
+            <RadioItem bind:group={radioValue} name={label} value={value} onchange={() => { !disabled ? valueChange({origin: options.label, newValue: value}) : radioValue = options.defaultValue }} id="{makeHtmlId(options.label)}-{makeHtmlId(value)}-button"
                             >
                             {#if options.keepLabelsCase}
                                 {label}
                             {:else}
                                 {label.toLowerCase()}
                             {/if}
-                            </RadioItem
-                        >
+                            </RadioItem>
+
         {/each}
         {/key}
     </RadioGroup>

--- a/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
+++ b/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
@@ -36,10 +36,19 @@
         }
     })
 
+    $effect(() => {
+        updateRadioValue(currentSelected[options.label])
+    })
+
+    function updateRadioValue(newValue) {
+        if (Object.values(options.values).includes(newValue)) {
+            radioValue = newValue;
+        } else {
+            radioValue = options.defaultValue;
+        }
+    }
 
 </script>
-
-{@debug currentSelected}
 
 
 <div class="flex flex-col gap-2 font-light text-xs md:text-sm  {disabled ? 'opacity-50 cursor-not-allowed' : ''}" data-testid="radio-group-{options.label}">

--- a/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
+++ b/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
@@ -31,7 +31,6 @@
 
 </script>
 
-{@debug radioValue}
 
 <div class="flex flex-col gap-2 font-light text-xs md:text-sm  {disabled ? 'opacity-50 cursor-not-allowed' : ''}" data-testid="radio-group-{options.label}">
     <label for="radio-group-{options.label}" class="hidden md:block font-light text-sm pl-4"

--- a/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
+++ b/src/lib/DataSelectorControls/DataRadioGroupControl.svelte
@@ -13,12 +13,20 @@
     import { onMount } from 'svelte';
 
 
-    let {options, valueChange, currentSelected, disabled = false} = $props();
+    let {options, valueChange, currentSelected} = $props();
     let radioValue = $state(undefined);
+    let disabled = $derived.by(() => {
+        if (currentSelected[options.label] === 'disabled') {
+            return true;
+        } else {
+            return false;
+        }
+    });
 
     onMount(() => {
         // choose correct currentSelected value based on label
         let correctCurrentSelected = currentSelected[options.label];
+        
         // checks to see if currentSelected is valid for this selector
         const validValues = Object.values(options.values);
         if (validValues.includes(correctCurrentSelected)) {
@@ -30,6 +38,8 @@
 
 
 </script>
+
+{@debug currentSelected}
 
 
 <div class="flex flex-col gap-2 font-light text-xs md:text-sm  {disabled ? 'opacity-50 cursor-not-allowed' : ''}" data-testid="radio-group-{options.label}">

--- a/src/lib/DataSelectorControls/DataSlideToggle.svelte
+++ b/src/lib/DataSelectorControls/DataSlideToggle.svelte
@@ -7,10 +7,10 @@
     @param options {object} - An object containing at least an object of options and their values and the value of the default value;
   -->
 <script>
-    import {SlideToggle} from '@skeletonlabs/skeleton';
-    import { onMount } from 'svelte';
+    import { SlideToggle } from "@skeletonlabs/skeleton";
+    import { onMount } from "svelte";
 
-    let {options, valueChange, currentValue} = $props();
+    let { options, valueChange, currentValue, disabled = false } = $props();
 
     let slideValue = $state(undefined);
 
@@ -20,17 +20,25 @@
         } else {
             slideValue = options.values.default;
         }
-    })
-
+    });
 </script>
 
-<div class="flex flex-col gap-2 font-light text-sm w-fit md:min-w-32 justify-center">
+<div
+    class="flex flex-col gap-2 font-light text-sm w-fit md:min-w-32 justify-center {disabled
+        ? 'opacity-50 cursor-not-allowed'
+        : ''}"
+>
     <label for="slide" class="font-light text-sm pl-2">{options.label}</label>
     <SlideToggle
         name="slide"
         bind:checked={slideValue}
         size="lg"
         background="bg-secondary-500"
-        active="bg-secondary-100" onchange={() => valueChange({origin: options.label, newValue: slideValue})}>{!slideValue ? "off" : "on"}</SlideToggle
+        active="bg-secondary-100"
+        onchange={() => {
+            !disabled
+                ? valueChange({ origin: options.label, newValue: slideValue })
+                : (slideValue = options.values.default);
+        }}>{!slideValue ? "off" : "on"}</SlideToggle
     >
 </div>

--- a/src/lib/DataSelectorControls/DataSlideToggle.svelte
+++ b/src/lib/DataSelectorControls/DataSlideToggle.svelte
@@ -10,9 +10,17 @@
     import { SlideToggle } from "@skeletonlabs/skeleton";
     import { onMount } from "svelte";
 
-    let { options, valueChange, currentValue, disabled = false } = $props();
+    let { options, valueChange, currentValue } = $props();
 
     let slideValue = $state(undefined);
+
+    let disabled = $derived.by(() => {
+        if (currentValue === 'disabled') {
+            return true;
+        } else {
+            return false;
+        }
+    });
 
     onMount(() => {
         if ([true, false].includes(currentValue)) {

--- a/src/lib/DataSelectorControls/DataSlideToggle.svelte
+++ b/src/lib/DataSelectorControls/DataSlideToggle.svelte
@@ -29,6 +29,18 @@
             slideValue = options.values.default;
         }
     });
+
+    $effect(() => {
+        updateRadioValue(currentValue);
+    })
+
+    function updateRadioValue(newValue) {
+        if ([true, false].includes(newValue)) {
+            slideValue = newValue;
+        } else {
+            slideValue = options.values.default;
+        }
+    }
 </script>
 
 <div

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -90,6 +90,10 @@
     });
 
     $effect(() => {
+        disableButtons(disabledButtons);
+    })
+
+    $effect(() => {
         if (teiViewerState.updateSection) {
             // checks to see if there is any section in state
             if (!teiViewerState.currentSection) {
@@ -658,11 +662,48 @@
         dataViewerState.navigatorChoice = false;
     }
 
+    function disableButtons(disabledButtons) {
+        let buttonDict = {
+            variation: () => {dataViewerState.variationDetail = "disabled"},
+            "editorial notes": () => {dataViewerState.editorialNotes = "disabled"},
+            translations: () => {dataViewerState.translations = "disabled"},
+            "navigator": () => {dataViewerState.activeNavigator = "disabled"},
+        }
+
+        let teiDefaultsDict =  {
+            activeView: "both",
+            variationDetail: "no variation",
+            editorialNotes: false,
+            translations: false,
+            activeNavigator: "titlepage"
+        }
+
+        if (disabledButtons != undefined) {
+            for(const button of disabledButtons) {
+                buttonDict[button]();
+            }
+        } else {
+            for(const key of Object.keys(dataViewerState)) {
+                if (dataViewerState[key] === "disabled") {
+                    dataViewerState[key] = teiDefaultsDict[key];
+                }
+            }
+        }
+    }
+
+    let disabledButtons = $derived.by(() => {
+        if (transcriptionData[dataViewerState.activeDataset] && transcriptionData[dataViewerState.activeDataset]["disabledButtons"]) {
+            return transcriptionData[dataViewerState.activeDataset]["disabledButtons"];
+        } else {
+            return undefined;
+        }
+    });
+
     onMount(() => {
         ready = false;
 
         // if activeDataset contains a value from the science view, reset to 1623
-        if (!["1623", "1609"].includes(dataViewerState.activeDataset)) {
+        if (!["1623", "1609", "1634"].includes(dataViewerState.activeDataset)) {
             dataViewerState.activeDataset = "1623";
             dataViewerState.activeView = "both";
         }
@@ -748,6 +789,7 @@
         ready = true;
     });
 </script>
+
 
 <svelte:window bind:innerWidth={windowSize} />
 

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -66,6 +66,13 @@
             teiViewerState.updateIIIF = false;
             teiViewerState.updateTEI = false;
             teiViewerState.updateSection = false;
+
+            // resets state for dataviewer
+            dataViewerState.activeNavigator = "titlepage";
+            dataViewerState.translations = false;
+            dataViewerState.variationDetail = "no variation";
+            dataViewerState.editorialNotes = false;
+
         }
     });
 
@@ -719,7 +726,6 @@
 
         if (disabledButtons && disabledButtons.length > 0) {
             for (const button of disabledButtons) {
-                console.log("Disabling button: ", button);
                 buttonDict[button]();
             }
         }

--- a/src/lib/TranscriptionViewer.svelte
+++ b/src/lib/TranscriptionViewer.svelte
@@ -91,7 +91,7 @@
 
     $effect(() => {
         disableButtons(disabledButtons);
-    })
+    });
 
     $effect(() => {
         if (teiViewerState.updateSection) {
@@ -105,34 +105,34 @@
                 "1623": {
                     "¶2r": "titlepage",
                     "¶3r": "preface",
-                    "A1v": "dedication",
-                    "A2r": "contents",
-                    "B1r": "ch1",
-                    "D4r": "ch2",
-                    "E4r": "ch3",
-                    "H1r": "ch4",
-                    "I3r": "ch5",
-                    "N3v": "ch6",
-                    "P4r": "ch7",
-                    "S2r": "ch8",
-                    "T1r": "ch9",
-                    "T2v": "ch10",
+                    A1v: "dedication",
+                    A2r: "contents",
+                    B1r: "ch1",
+                    D4r: "ch2",
+                    E4r: "ch3",
+                    H1r: "ch4",
+                    I3r: "ch5",
+                    N3v: "ch6",
+                    P4r: "ch7",
+                    S2r: "ch8",
+                    T1r: "ch9",
+                    T2v: "ch10",
                 },
                 "1609": {
-                    "a1r": "titlepage",
-                    "a2r": "preface",
-                    "a4v": "dedication",
-                    "b1v": "contents",
-                    "A1r": "ch1",
-                    "B8r": "ch2",
-                    "C3v": "ch3",
-                    "D5r": "ch4",
-                    "E5r": "ch5",
-                    "G2r": "ch6",
-                    "H4v": "ch7",
-                    "I7r": "ch8",
-                    "K1r": "ch9",
-                    "K5r": "ch10",
+                    a1r: "titlepage",
+                    a2r: "preface",
+                    a4v: "dedication",
+                    b1v: "contents",
+                    A1r: "ch1",
+                    B8r: "ch2",
+                    C3v: "ch3",
+                    D5r: "ch4",
+                    E5r: "ch5",
+                    G2r: "ch6",
+                    H4v: "ch7",
+                    I7r: "ch8",
+                    K1r: "ch9",
+                    K5r: "ch10",
                 },
             };
 
@@ -179,12 +179,11 @@
                         ch8: 164 + offset,
                         ch9: 168 + offset,
                         ch10: 176 + offset,
-                    }
+                    },
                 };
 
                 let startingPages =
                     startingPagesDict[dataViewerState.activeDataset.toString()];
-
 
                 // check where the current page sits in the starting pages
                 for (const [i, key] of Object.keys(startingPages).entries()) {
@@ -276,6 +275,7 @@
     import transcriptionData from "../routes/(sections)/literature/transcription/transcriptionData.json";
     import { findLastMilestoneBefore } from "../utils/generalHelpers";
     import { isElementVisibleInViewport } from "../utils/teiBehavioursHelper";
+    import { active } from "d3";
 
     function cleanVariationStyles(el) {
         // removes any bg styling for the element
@@ -648,7 +648,7 @@
                         ch9: "K1r",
                         ch10: "K5r",
                     },
-                }
+                };
 
                 let startingSigs =
                     startingSigsDict[dataViewerState.activeDataset.toString()];
@@ -664,36 +664,108 @@
 
     function disableButtons(disabledButtons) {
         let buttonDict = {
-            variation: () => {dataViewerState.variationDetail = "disabled"},
-            "editorial notes": () => {dataViewerState.editorialNotes = "disabled"},
-            translations: () => {dataViewerState.translations = "disabled"},
-            "navigator": () => {dataViewerState.activeNavigator = "disabled"},
-        }
+            variation: () => {
+                dataViewerState.variationDetail = "disabled";
+            },
+            "editorial notes": () => {
+                dataViewerState.editorialNotes = "disabled";
+            },
+            translations: () => {
+                dataViewerState.translations = "disabled";
+            },
+            navigator: () => {
+                dataViewerState.activeNavigator = "disabled";
+            },
+            view: () => {
+                // Setting it as disabled would interfere with the facsimile display; although it is a little hacky, the preferred solution is to deactivate the buttons from the transcription viewer
+                let viewOptions = document.querySelector(
+                    "div[data-testid='radio-group-view']",
+                );
+                dataViewerState.activeView = "facsimile";
+                // This flag is so that reactivating the buttons doesn't miss 'view' (which would display the facsimile view)
+                dataViewerState.viewOptionsDisabled = true;
+                if (viewOptions) {
+                    viewOptions.classList.add(
+                        "opacity-50",
+                        "cursor-not-allowed",
+                    );
+                    // add cursor not-allowed to all radio items
+                    let radioItems = viewOptions.querySelectorAll(
+                        "input[type='radio']",
+                    );
+                    for (const item of radioItems) {
+                        item.disabled = true;
+                        item.classList.add("cursor-not-allowed");
+                    }
+                }
+            },
+        };
 
-        let teiDefaultsDict =  {
+        let teiDefaultsDict = {
             activeView: "both",
             variationDetail: "no variation",
             editorialNotes: false,
             translations: false,
-            activeNavigator: "titlepage"
-        }
+            activeNavigator: "titlepage",
+        };
 
-        if (disabledButtons != undefined) {
-            for(const button of disabledButtons) {
+        let defaultsToButtons = {
+            activeView: "view",
+            variationDetail: "variation",
+            editorialNotes: "editorial notes",
+            translations: "translations",
+            activeNavigator: "navigator",
+        };
+
+        if (disabledButtons && disabledButtons.length > 0) {
+            for (const button of disabledButtons) {
+                console.log("Disabling button: ", button);
                 buttonDict[button]();
             }
-        } else {
-            for(const key of Object.keys(dataViewerState)) {
-                if (dataViewerState[key] === "disabled") {
-                    dataViewerState[key] = teiDefaultsDict[key];
+        }
+
+        for (const key of Object.keys(dataViewerState)) {
+            if (
+                dataViewerState[key] === "disabled" &&
+                (disabledButtons === undefined || !disabledButtons.includes(defaultsToButtons[key]))
+            ) {
+                dataViewerState[key] = teiDefaultsDict[key];
+            } else if (
+                dataViewerState[key] === "facsimile" &&
+                dataViewerState.viewOptionsDisabled && (disabledButtons === undefined ||
+                !disabledButtons.includes(defaultsToButtons[key]))
+            ) {
+                dataViewerState[key] = teiDefaultsDict[key];
+                dataViewerState.viewOptionsDisabled = false;
+                let viewOptions = document.querySelector(
+                    "div[data-testid='radio-group-view']",
+                );
+                if (viewOptions) {
+                    viewOptions.classList.remove(
+                        "opacity-50",
+                        "cursor-not-allowed",
+                    );
+                    // remove cursor not-allowed from all radio items
+                    let radioItems = viewOptions.querySelectorAll(
+                        "input[type='radio']",
+                    );
+                    for (const item of radioItems) {
+                        item.disabled = false;
+                        item.classList.remove("cursor-not-allowed");
+                    }
                 }
             }
         }
     }
 
     let disabledButtons = $derived.by(() => {
-        if (transcriptionData[dataViewerState.activeDataset] && transcriptionData[dataViewerState.activeDataset]["disabledButtons"]) {
-            return transcriptionData[dataViewerState.activeDataset]["disabledButtons"];
+        if (
+            transcriptionData[dataViewerState.activeDataset] &&
+            transcriptionData[dataViewerState.activeDataset]["disabledButtons"]
+        ) {
+            return transcriptionData[dataViewerState.activeDataset][
+                "disabledButtons"
+            ];
         } else {
             return undefined;
         }
@@ -789,7 +861,6 @@
         ready = true;
     });
 </script>
-
 
 <svelte:window bind:innerWidth={windowSize} />
 

--- a/src/routes/(sections)/literature/transcription/transcriptionData.json
+++ b/src/routes/(sections)/literature/transcription/transcriptionData.json
@@ -5,7 +5,12 @@
         "manifestStartPage": "1",
         "pdfFallback": "./bim_early-english-books-1475-1640_the-feminine-monarchie-_butler-charles_1609.pdf",
         "pdfFallbackStartPage": 1,
-        "title": "1609 facsimile"
+        "title": "1609 facsimile",
+        "disabledButtons": [
+            "variation",
+            "editorial notes",
+            "translations"
+        ]
     },
     "1623": {
         "teiURL": "https://raw.githubusercontent.com/NewcastleRSE/beeing-human-tei-data/refs/heads/dev/1623_consolidated.xml",
@@ -28,7 +33,8 @@
             "variation",
             "editorial notes",
             "translations",
-            "navigator"
+            "navigator",
+            "view"
         ]
     }
 }

--- a/src/routes/(sections)/literature/transcription/transcriptionData.json
+++ b/src/routes/(sections)/literature/transcription/transcriptionData.json
@@ -23,6 +23,12 @@
         "manifestStartPage": "11",
         "pdfFallback": "./feminine_monarchie_1634.pdf",
         "pdfFallbackStartPage": 12,
-        "title": "1634 facsimile"
+        "title": "1634 facsimile",
+        "disabledButtons": [
+            "variation",
+            "editorial notes",
+            "translations",
+            "navigator"
+        ]
     }
 }

--- a/src/stores/dataViewer.svelte.js
+++ b/src/stores/dataViewer.svelte.js
@@ -5,5 +5,6 @@ export const dataViewerState = $state({
     editorialNotes: false,
     activeNavigator: '',
     navigatorChoice: false,
-    translations: false
+    translations: false,
+    viewOptionsDisabled: false,
 })


### PR DESCRIPTION
## Description

Deactivates options in the `DataSelector` if the data source does not support them (i.e., notes in 1609 and 1634, views in 1634, etc)
Buttons in the `DataSelector` can now be updated programmatically, so they need to display state

Fixes #281 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Manual and automated testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## What should reviewers look for?

Please provide any specific areas of feedback you're looking for from reviewers.

<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
